### PR TITLE
problem: react will ignore non camel-case svg properties

### DIFF
--- a/lib/icons3/Add.js
+++ b/lib/icons3/Add.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 32h24M32 20v24M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 32h24M32 20v24M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Add.js.flow
+++ b/lib/icons3/Add.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Add = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M32 20v24M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 32h24M32 20v24M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/AddCircle.js
+++ b/lib/icons3/AddCircle.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 32h24M32 20v24' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 32h24M32 20v24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/AddCircle.js.flow
+++ b/lib/icons3/AddCircle.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const AddCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M32 20v24"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 32h24M32 20v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/AppleCommand.js
+++ b/lib/icons3/AppleCommand.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/AppleCommand.js.flow
+++ b/lib/icons3/AppleCommand.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const AppleCommand = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z"/>
+    <path fill="none" stroke="currentColor" d="M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowDown.js
+++ b/lib/icons3/ArrowDown.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 44l8 8 8-8M32 12v40' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 44l8 8 8-8M32 12v40', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowDown.js.flow
+++ b/lib/icons3/ArrowDown.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowDown = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 44l8 8 8-8M32 12v40"/>
+    <path fill="none" stroke="currentColor" d="M24 44l8 8 8-8M32 12v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowDownBoxed.js
+++ b/lib/icons3/ArrowDownBoxed.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 28l8 8 8-8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 28l8 8 8-8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowDownBoxed.js.flow
+++ b/lib/icons3/ArrowDownBoxed.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowDownBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 28l8 8 8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M24 28l8 8 8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowLeft.js
+++ b/lib/icons3/ArrowLeft.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 24l-8 8 8 8M52 32H12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 24l-8 8 8 8M52 32H12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowLeft.js.flow
+++ b/lib/icons3/ArrowLeft.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowLeft = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 24l-8 8 8 8M52 32H12"/>
+    <path fill="none" stroke="currentColor" d="M20 24l-8 8 8 8M52 32H12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowLeftBoxed.js
+++ b/lib/icons3/ArrowLeftBoxed.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 24l-8 8 8 8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 24l-8 8 8 8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowLeftBoxed.js.flow
+++ b/lib/icons3/ArrowLeftBoxed.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowLeftBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 24l-8 8 8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M36 24l-8 8 8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowRight.js
+++ b/lib/icons3/ArrowRight.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M44 40l8-8-8-8M52 32H12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M44 40l8-8-8-8M52 32H12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowRight.js.flow
+++ b/lib/icons3/ArrowRight.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowRight = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 40l8-8-8-8M52 32H12"/>
+    <path fill="none" stroke="currentColor" d="M44 40l8-8-8-8M52 32H12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowRightBoxed.js
+++ b/lib/icons3/ArrowRightBoxed.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 40l8-8-8-8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 40l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowRightBoxed.js.flow
+++ b/lib/icons3/ArrowRightBoxed.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowRightBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowUp.js
+++ b/lib/icons3/ArrowUp.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 20l-8-8-8 8M32 12v40' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 20l-8-8-8 8M32 12v40', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowUp.js.flow
+++ b/lib/icons3/ArrowUp.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowUp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 20l-8-8-8 8M32 12v40"/>
+    <path fill="none" stroke="currentColor" d="M40 20l-8-8-8 8M32 12v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ArrowUpBoxed.js
+++ b/lib/icons3/ArrowUpBoxed.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 36l-8-8-8 8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 36l-8-8-8 8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ArrowUpBoxed.js.flow
+++ b/lib/icons3/ArrowUpBoxed.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowUpBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 36l-8-8-8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M40 36l-8-8-8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Back.js
+++ b/lib/icons3/Back.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 52L20 32l20-20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 52L20 32l20-20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Back.js.flow
+++ b/lib/icons3/Back.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Back = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 52L20 32l20-20"/>
+    <path fill="none" stroke="currentColor" d="M40 52L20 32l20-20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Ball.js
+++ b/lib/icons3/Ball.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Ball.js.flow
+++ b/lib/icons3/Ball.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Ball = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BarChart.js
+++ b/lib/icons3/BarChart.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56H8V36M20 20v36M32 32v24M44 8v48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56H8V36M20 20v36M32 32v24M44 8v48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BarChart.js.flow
+++ b/lib/icons3/BarChart.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BarChart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56H8V36M20 20v36M32 32v24M44 8v48"/>
+    <path fill="none" stroke="currentColor" d="M56 56H8V36M20 20v36M32 32v24M44 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Battery100.js
+++ b/lib/icons3/Battery100.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Battery100.js.flow
+++ b/lib/icons3/Battery100.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery100 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Battery25.js
+++ b/lib/icons3/Battery25.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Battery25.js.flow
+++ b/lib/icons3/Battery25.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery25 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Battery50.js
+++ b/lib/icons3/Battery50.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Battery50.js.flow
+++ b/lib/icons3/Battery50.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery50 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Battery75.js
+++ b/lib/icons3/Battery75.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Battery75.js.flow
+++ b/lib/icons3/Battery75.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery75 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BatteryEmpty.js
+++ b/lib/icons3/BatteryEmpty.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24v-8H8v32h40v-8h8V24h-8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24v-8H8v32h40v-8h8V24h-8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BatteryEmpty.js.flow
+++ b/lib/icons3/BatteryEmpty.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BatteryEmpty = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8z"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Block.js
+++ b/lib/icons3/Block.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 20v24l24 12 24-12V20L32 8 8 20z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 20L32 32 8 20M32 32v24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 20v24l24 12 24-12V20L32 8 8 20z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 20L32 32 8 20M32 32v24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Block.js.flow
+++ b/lib/icons3/Block.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Block = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20v24l24 12 24-12V20L32 8 8 20z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20L32 32 8 20M32 32v24"/>
+    <path fill="none" stroke="currentColor" d="M8 20v24l24 12 24-12V20L32 8 8 20z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 20L32 32 8 20M32 32v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Block3d.js
+++ b/lib/icons3/Block3d.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Block3d.js.flow
+++ b/lib/icons3/Block3d.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Block3d = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24"/>
+    <path fill="none" stroke="currentColor" d="M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Bluetooth.js
+++ b/lib/icons3/Bluetooth.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 40l20-16-12-12v40l12-12-20-16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 40l20-16-12-12v40l12-12-20-16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Bluetooth.js.flow
+++ b/lib/icons3/Bluetooth.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Bluetooth = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 40l20-16-12-12v40l12-12-20-16"/>
+    <path fill="none" stroke="currentColor" d="M20 40l20-16-12-12v40l12-12-20-16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Book.js
+++ b/lib/icons3/Book.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Book.js.flow
+++ b/lib/icons3/Book.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Book = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44"/>
+    <path fill="none" stroke="currentColor" d="M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Box.js
+++ b/lib/icons3/Box.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Box.js.flow
+++ b/lib/icons3/Box.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Box = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxContainer.js
+++ b/lib/icons3/BoxContainer.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 8h32l8 16v32H8V24l8-16zM8 24h48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 8h32l8 16v32H8V24l8-16zM8 24h48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxContainer.js.flow
+++ b/lib/icons3/BoxContainer.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxContainer = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 8h32l8 16v32H8V24l8-16zM8 24h48"/>
+    <path fill="none" stroke="currentColor" d="M16 8h32l8 16v32H8V24l8-16zM8 24h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitBackslash.js
+++ b/lib/icons3/BoxSplitBackslash.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM56 56L8 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM56 56L8 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitBackslash.js.flow
+++ b/lib/icons3/BoxSplitBackslash.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitBackslash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 56L8 8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 56L8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitCross.js
+++ b/lib/icons3/BoxSplitCross.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM56 8L8 56M56 56L8 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM56 8L8 56M56 56L8 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitCross.js.flow
+++ b/lib/icons3/BoxSplitCross.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 8L8 56M56 56L8 8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 8L8 56M56 56L8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitHorizontal.js
+++ b/lib/icons3/BoxSplitHorizontal.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM8 32h48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM8 32h48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitHorizontal.js.flow
+++ b/lib/icons3/BoxSplitHorizontal.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 32h48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitHorizontalVertical.js
+++ b/lib/icons3/BoxSplitHorizontalVertical.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM32 56V8M8 32h48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM32 56V8M8 32h48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitHorizontalVertical.js.flow
+++ b/lib/icons3/BoxSplitHorizontalVertical.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitHorizontalVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM32 56V8M8 32h48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM32 56V8M8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitSlash.js
+++ b/lib/icons3/BoxSplitSlash.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM56 8L8 56' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM56 8L8 56', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitSlash.js.flow
+++ b/lib/icons3/BoxSplitSlash.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitSlash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 8L8 56"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 8L8 56" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxSplitVertical.js
+++ b/lib/icons3/BoxSplitVertical.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM32 56V8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM32 56V8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxSplitVertical.js.flow
+++ b/lib/icons3/BoxSplitVertical.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM32 56V8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM32 56V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxedExport.js
+++ b/lib/icons3/BoxedExport.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M52 32v24H8V12h24M56 24V8H40M36 28L56 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M52 32v24H8V12h24M56 24V8H40M36 28L56 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxedExport.js.flow
+++ b/lib/icons3/BoxedExport.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxedExport = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 32v24H8V12h24M56 24V8H40M36 28L56 8"/>
+    <path fill="none" stroke="currentColor" d="M52 32v24H8V12h24M56 24V8H40M36 28L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/BoxedImport.js
+++ b/lib/icons3/BoxedImport.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M52 40v16H8V12h16' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 12v16h16M56 8L36 28' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M52 40v16H8V12h16', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 12v16h16M56 8L36 28', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/BoxedImport.js.flow
+++ b/lib/icons3/BoxedImport.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxedImport = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 40v16H8V12h16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 12v16h16M56 8L36 28"/>
+    <path fill="none" stroke="currentColor" d="M52 40v16H8V12h16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M36 12v16h16M56 8L36 28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Browser.js
+++ b/lib/icons3/Browser.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Browser.js.flow
+++ b/lib/icons3/Browser.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Browser = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Bulp.js
+++ b/lib/icons3/Bulp.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Bulp.js.flow
+++ b/lib/icons3/Bulp.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Bulp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Camera.js
+++ b/lib/icons3/Camera.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '8', y: '20', width: '48', height: '36', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 20l4-12h24l4 12' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '38', r: '10', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('rect', { x: '8', y: '20', width: '48', height: '36', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 20l4-12h24l4 12', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '38', r: '10', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Camera.js.flow
+++ b/lib/icons3/Camera.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Camera = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="20" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 20l4-12h24l4 12"/><circle cx="32" cy="38" r="10" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <rect x="8" y="20" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 20l4-12h24l4 12" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="38" r="10" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Chat.js
+++ b/lib/icons3/Chat.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Chat.js.flow
+++ b/lib/icons3/Chat.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Chat = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Check1.js
+++ b/lib/icons3/Check1.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Check1.js.flow
+++ b/lib/icons3/Check1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Check1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2"/>
+    <path fill="none" stroke="currentColor" d="M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Check2.js
+++ b/lib/icons3/Check2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M44 24L28 40l-8-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M44 24L28 40l-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Check2.js.flow
+++ b/lib/icons3/Check2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Check2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 24L28 40l-8-8"/>
+    <path fill="none" stroke="currentColor" d="M44 24L28 40l-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Checkmark.js
+++ b/lib/icons3/Checkmark.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M12 28l16 16 24-24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M12 28l16 16 24-24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Checkmark.js.flow
+++ b/lib/icons3/Checkmark.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Checkmark = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 28l16 16 24-24"/>
+    <path fill="none" stroke="currentColor" d="M12 28l16 16 24-24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Circle.js
+++ b/lib/icons3/Circle.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Circle.js.flow
+++ b/lib/icons3/Circle.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Circle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitBackslash.js
+++ b/lib/icons3/CircleSplitBackslash.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M15.03 15.04l33.93 33.93' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M15.03 15.04l33.93 33.93', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitBackslash.js.flow
+++ b/lib/icons3/CircleSplitBackslash.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitBackslash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 15.04l33.93 33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 15.04l33.93 33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitCross.js
+++ b/lib/icons3/CircleSplitCross.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitCross.js.flow
+++ b/lib/icons3/CircleSplitCross.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitHorizontal.js
+++ b/lib/icons3/CircleSplitHorizontal.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 32h48' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 32h48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitHorizontal.js.flow
+++ b/lib/icons3/CircleSplitHorizontal.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 32h48"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitHorizontalVertical.js
+++ b/lib/icons3/CircleSplitHorizontalVertical.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v48M56 32H8' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v48M56 32H8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitHorizontalVertical.js.flow
+++ b/lib/icons3/CircleSplitHorizontalVertical.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitHorizontalVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M56 32H8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48M56 32H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitSlash.js
+++ b/lib/icons3/CircleSplitSlash.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M15.03 48.97l33.93-33.93' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M15.03 48.97l33.93-33.93', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitSlash.js.flow
+++ b/lib/icons3/CircleSplitSlash.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitSlash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 48.97l33.93-33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 48.97l33.93-33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CircleSplitVertical.js
+++ b/lib/icons3/CircleSplitVertical.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v48' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CircleSplitVertical.js.flow
+++ b/lib/icons3/CircleSplitVertical.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Cli.js
+++ b/lib/icons3/Cli.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 12h48v40H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 40l8-8-8-8M32 40h12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 12h48v40H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 40l8-8-8-8M32 40h12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Cli.js.flow
+++ b/lib/icons3/Cli.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Cli = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 40l8-8-8-8M32 40h12"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 40l8-8-8-8M32 40h12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Close.js
+++ b/lib/icons3/Close.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 16l32 32M48 16L16 48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 16l32 32M48 16L16 48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Close.js.flow
+++ b/lib/icons3/Close.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Close = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 16l32 32M48 16L16 48"/>
+    <path fill="none" stroke="currentColor" d="M16 16l32 32M48 16L16 48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CloseBoxed.js
+++ b/lib/icons3/CloseBoxed.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 20l24 24M44 20L20 44M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 20l24 24M44 20L20 44M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CloseBoxed.js.flow
+++ b/lib/icons3/CloseBoxed.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CloseBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20l24 24M44 20L20 44M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 20l24 24M44 20L20 44M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Code.js
+++ b/lib/icons3/Code.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Code.js.flow
+++ b/lib/icons3/Code.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Code = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48"/>
+    <path fill="none" stroke="currentColor" d="M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Coffee.js
+++ b/lib/icons3/Coffee.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Coffee.js.flow
+++ b/lib/icons3/Coffee.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Coffee = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Compass.js
+++ b/lib/icons3/Compass.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 28l-4 12 12-4 4-12-12 4z' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 28l-4 12 12-4 4-12-12 4z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Compass.js.flow
+++ b/lib/icons3/Compass.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Compass = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 28l-4 12 12-4 4-12-12 4z"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 28l-4 12 12-4 4-12-12 4z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Contract.js
+++ b/lib/icons3/Contract.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 12h48v40H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 12h48v40H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Contract.js.flow
+++ b/lib/icons3/Contract.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contract = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Contractabi.js
+++ b/lib/icons3/Contractabi.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Contractabi.js.flow
+++ b/lib/icons3/Contractabi.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractabi = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20"/>
+    <path fill="none" stroke="currentColor" d="M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Contractexecute1.js
+++ b/lib/icons3/Contractexecute1.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 56V24h32' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 48l8-8-8-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 56V24h32', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 48l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Contractexecute1.js.flow
+++ b/lib/icons3/Contractexecute1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56V24h32"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48l8-8-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 56V24h32" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M36 48l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Contractexecute2.js
+++ b/lib/icons3/Contractexecute2.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 48l8-8-8-8' }),
-      _react2.default.createElement('circle', { cx: '40', cy: '40', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 48l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '40', cy: '40', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Contractexecute2.js.flow
+++ b/lib/icons3/Contractexecute2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48l8-8-8-8"/><circle cx="40" cy="40" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4"/>
+    <path fill="none" stroke="currentColor" d="M36 48l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><circle cx="40" cy="40" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Contractexecute3.js
+++ b/lib/icons3/Contractexecute3.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 12h48v40H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 40l8-8-8-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 12h48v40H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 40l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Contractexecute3.js.flow
+++ b/lib/icons3/Contractexecute3.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Copytoclipboard.js
+++ b/lib/icons3/Copytoclipboard.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 40H8V8h32v16' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 24h32v32H24z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 40H8V8h32v16', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 24h32v32H24z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Copytoclipboard.js.flow
+++ b/lib/icons3/Copytoclipboard.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Copytoclipboard = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 40H8V8h32v16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h32v32H24z"/>
+    <path fill="none" stroke="currentColor" d="M24 40H8V8h32v16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24h32v32H24z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Crop.js
+++ b/lib/icons3/Crop.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 48H16V8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 16h40v40M8 56L56 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 48H16V8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 16h40v40M8 56L56 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Crop.js.flow
+++ b/lib/icons3/Crop.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Crop = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 48H16V8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 16h40v40M8 56L56 8"/>
+    <path fill="none" stroke="currentColor" d="M56 48H16V8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 16h40v40M8 56L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Crosscursor.js
+++ b/lib/icons3/Crosscursor.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Crosscursor.js.flow
+++ b/lib/icons3/Crosscursor.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Crosscursor = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8"/>
+    <path fill="none" stroke="currentColor" d="M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyBtc.js
+++ b/lib/icons3/CurrencyBtc.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyBtc.js.flow
+++ b/lib/icons3/CurrencyBtc.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyBtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyEtc.js
+++ b/lib/icons3/CurrencyEtc.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56L16 32 32 8l16 24-16 24z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32l16-8 16 8M16 32l16 8 16-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56L16 32 32 8l16 24-16 24z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32l16-8 16 8M16 32l16 8 16-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyEtc.js.flow
+++ b/lib/icons3/CurrencyEtc.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyEtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16-8 16 8M16 32l16 8 16-8"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16-8 16 8M16 32l16 8 16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyEth.js
+++ b/lib/icons3/CurrencyEth.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56L16 32 32 8l16 24-16 24z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32l16 8 16-8M32 8v48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56L16 32 32 8l16 24-16 24z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32l16 8 16-8M32 8v48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyEth.js.flow
+++ b/lib/icons3/CurrencyEth.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyEth = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16 8 16-8M32 8v48"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16 8 16-8M32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyLtc.js
+++ b/lib/icons3/CurrencyLtc.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 16l-8 32h24M36 28l-20 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 16l-8 32h24M36 28l-20 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyLtc.js.flow
+++ b/lib/icons3/CurrencyLtc.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyLtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 16l-8 32h24M36 28l-20 8"/>
+    <path fill="none" stroke="currentColor" d="M28 16l-8 32h24M36 28l-20 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyUsd.js
+++ b/lib/icons3/CurrencyUsd.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyUsd.js.flow
+++ b/lib/icons3/CurrencyUsd.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyUsd = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyXmr.js
+++ b/lib/icons3/CurrencyXmr.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 48h-8V16L32 32 16 16v32H8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 48h-8V16L32 32 16 16v32H8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyXmr.js.flow
+++ b/lib/icons3/CurrencyXmr.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyXmr = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 48h-8V16L32 32 16 16v32H8"/>
+    <path fill="none" stroke="currentColor" d="M56 48h-8V16L32 32 16 16v32H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/CurrencyZec.js
+++ b/lib/icons3/CurrencyZec.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 16h28L20 48h28M32 8v8M32 48v8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 16h28L20 48h28M32 8v8M32 48v8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/CurrencyZec.js.flow
+++ b/lib/icons3/CurrencyZec.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyZec = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 16h28L20 48h28M32 8v8M32 48v8"/>
+    <path fill="none" stroke="currentColor" d="M16 16h28L20 48h28M32 8v8M32 48v8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Dashboard.js
+++ b/lib/icons3/Dashboard.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Dashboard.js.flow
+++ b/lib/icons3/Dashboard.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Dashboard = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Database.js
+++ b/lib/icons3/Database.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Database.js.flow
+++ b/lib/icons3/Database.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Database = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Disk.js
+++ b/lib/icons3/Disk.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '6', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '6', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Disk.js.flow
+++ b/lib/icons3/Disk.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Disk = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Display.js
+++ b/lib/icons3/Display.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '8', y: '8', width: '48', height: '36', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 56h32M28 44l-4 12M36 44l4 12M8 36h48' })
+      _react2.default.createElement('rect', { x: '8', y: '8', width: '48', height: '36', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 56h32M28 44l-4 12M36 44l4 12M8 36h48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Display.js.flow
+++ b/lib/icons3/Display.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Display = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="8" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 56h32M28 44l-4 12M36 44l4 12M8 36h48"/>
+    <rect x="8" y="8" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 56h32M28 44l-4 12M36 44l4 12M8 36h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/DoorEnter.js
+++ b/lib/icons3/DoorEnter.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 20V8h32v48H16V44' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 40l8-8-8-8M8 32h28' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 20V8h32v48H16V44', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 40l8-8-8-8M8 32h28', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/DoorEnter.js.flow
+++ b/lib/icons3/DoorEnter.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DoorEnter = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 20V8h32v48H16V44"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8M8 32h28"/>
+    <path fill="none" stroke="currentColor" d="M16 20V8h32v48H16V44" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8M8 32h28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/DoorExit.js
+++ b/lib/icons3/DoorExit.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/DoorExit.js.flow
+++ b/lib/icons3/DoorExit.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DoorExit = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28"/>
+    <path fill="none" stroke="currentColor" d="M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Download.js
+++ b/lib/icons3/Download.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Download.js.flow
+++ b/lib/icons3/Download.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Download = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4"/>
+    <path fill="none" stroke="currentColor" d="M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Drop.js
+++ b/lib/icons3/Drop.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Drop.js.flow
+++ b/lib/icons3/Drop.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Drop = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/DropdownArrowDown.js
+++ b/lib/icons3/DropdownArrowDown.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24L32 40 16 24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24L32 40 16 24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/DropdownArrowDown.js.flow
+++ b/lib/icons3/DropdownArrowDown.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DropdownArrowDown = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24L32 40 16 24"/>
+    <path fill="none" stroke="currentColor" d="M48 24L32 40 16 24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/DropdownArrowUp.js
+++ b/lib/icons3/DropdownArrowUp.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 40l16-16 16 16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 40l16-16 16 16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/DropdownArrowUp.js.flow
+++ b/lib/icons3/DropdownArrowUp.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DropdownArrowUp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40l16-16 16 16"/>
+    <path fill="none" stroke="currentColor" d="M16 40l16-16 16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Education.js
+++ b/lib/icons3/Education.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 36L8 24l24-12 24 12-24 12z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 28v24H16V28M56 24v20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 36L8 24l24-12 24 12-24 12z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 28v24H16V28M56 24v20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Education.js.flow
+++ b/lib/icons3/Education.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Education = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 36L8 24l24-12 24 12-24 12z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 28v24H16V28M56 24v20"/>
+    <path fill="none" stroke="currentColor" d="M32 36L8 24l24-12 24 12-24 12z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 28v24H16V28M56 24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Email.js
+++ b/lib/icons3/Email.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 12h48v40H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 20L32 36 8 20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 12h48v40H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 20L32 36 8 20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Email.js.flow
+++ b/lib/icons3/Email.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Email = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20L32 36 8 20"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 20L32 36 8 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/EmailOpen.js
+++ b/lib/icons3/EmailOpen.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 20l-24-8-24 8v32h48V20z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 28l-16 8-16-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 20l-24-8-24 8v32h48V20z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 28l-16 8-16-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/EmailOpen.js.flow
+++ b/lib/icons3/EmailOpen.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmailOpen = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20l-24-8-24 8v32h48V20z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 28l-16 8-16-8"/>
+    <path fill="none" stroke="currentColor" d="M56 20l-24-8-24 8v32h48V20z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 28l-16 8-16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/EmoteHappy.js
+++ b/lib/icons3/EmoteHappy.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M40.49 40a12 12 0 0 1-17 0', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 24h-4M28 24h-4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { d: 'M40.49 40a12 12 0 0 1-17 0', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 24h-4M28 24h-4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/EmoteHappy.js.flow
+++ b/lib/icons3/EmoteHappy.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmoteHappy = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M40.49 40a12 12 0 0 1-17 0" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h-4M28 24h-4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M40.49 40a12 12 0 0 1-17 0" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M40 24h-4M28 24h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/EmoteSad.js
+++ b/lib/icons3/EmoteSad.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M23.51 43.51a12 12 0 0 1 17 0', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 24h-4M28 24h-4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { d: 'M23.51 43.51a12 12 0 0 1 17 0', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 24h-4M28 24h-4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/EmoteSad.js.flow
+++ b/lib/icons3/EmoteSad.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmoteSad = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M23.51 43.51a12 12 0 0 1 17 0" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h-4M28 24h-4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M23.51 43.51a12 12 0 0 1 17 0" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M40 24h-4M28 24h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Etc.js
+++ b/lib/icons3/Etc.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56L16 32 32 8l16 24-16 24z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32l16-8 16 8M16 32l16 8 16-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56L16 32 32 8l16 24-16 24z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32l16-8 16 8M16 32l16 8 16-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Etc.js.flow
+++ b/lib/icons3/Etc.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Etc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16-8 16 8M16 32l16 8 16-8"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16-8 16 8M16 32l16 8 16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/EtcSimple.js
+++ b/lib/icons3/EtcSimple.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56L16 32 32 8l16 24-16 24zM16 32h32' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56L16 32 32 8l16 24-16 24zM16 32h32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/EtcSimple.js.flow
+++ b/lib/icons3/EtcSimple.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EtcSimple = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24zM16 32h32"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24zM16 32h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Export.js
+++ b/lib/icons3/Export.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 24L32 8 16 24M56 56H8M32 48V8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 24L32 8 16 24M56 56H8M32 48V8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Export.js.flow
+++ b/lib/icons3/Export.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Export = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24L32 8 16 24M56 56H8M32 48V8"/>
+    <path fill="none" stroke="currentColor" d="M48 24L32 8 16 24M56 56H8M32 48V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/File.js
+++ b/lib/icons3/File.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M12 8h40v48H12z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M12 8h40v48H12z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/File.js.flow
+++ b/lib/icons3/File.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const File = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 8h40v48H12z"/>
+    <path fill="none" stroke="currentColor" d="M12 8h40v48H12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Flag.js
+++ b/lib/icons3/Flag.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32h32L36 20 48 8H16v48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32h32L36 20 48 8H16v48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Flag.js.flow
+++ b/lib/icons3/Flag.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Flag = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32L36 20 48 8H16v48"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32L36 20 48 8H16v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Folder.js
+++ b/lib/icons3/Folder.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 20l-4-8H8v40h48V20H28z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 20l-4-8H8v40h48V20H28z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Folder.js.flow
+++ b/lib/icons3/Folder.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Folder = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 20l-4-8H8v40h48V20H28z"/>
+    <path fill="none" stroke="currentColor" d="M28 20l-4-8H8v40h48V20H28z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Forward.js
+++ b/lib/icons3/Forward.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 12l20 20-20 20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 12l20 20-20 20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Forward.js.flow
+++ b/lib/icons3/Forward.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Forward = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 12l20 20-20 20"/>
+    <path fill="none" stroke="currentColor" d="M24 12l20 20-20 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/FullscreenExpand.js
+++ b/lib/icons3/FullscreenExpand.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 48h12V36M28 16H16v12' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM16 16l12 12M48 48L36 36' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 48h12V36M28 16H16v12', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM16 16l12 12M48 48L36 36', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/FullscreenExpand.js.flow
+++ b/lib/icons3/FullscreenExpand.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const FullscreenExpand = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48h12V36M28 16H16v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM16 16l12 12M48 48L36 36"/>
+    <path fill="none" stroke="currentColor" d="M36 48h12V36M28 16H16v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8zM16 16l12 12M48 48L36 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/FullscreenShrink.js
+++ b/lib/icons3/FullscreenShrink.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 36H36v12' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM36 36l12 12' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 28h12V16M28 28L16 16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 36H36v12', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM36 36l12 12', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 28h12V16M28 28L16 16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/FullscreenShrink.js.flow
+++ b/lib/icons3/FullscreenShrink.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const FullscreenShrink = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 36H36v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM36 36l12 12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 28h12V16M28 28L16 16"/>
+    <path fill="none" stroke="currentColor" d="M48 36H36v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8zM36 36l12 12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 28h12V16M28 28L16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Game.js
+++ b/lib/icons3/Game.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Game.js.flow
+++ b/lib/icons3/Game.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Game = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Globe.js
+++ b/lib/icons3/Globe.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Globe.js.flow
+++ b/lib/icons3/Globe.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Globe = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/GroundPlan.js
+++ b/lib/icons3/GroundPlan.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM8 40h48M24 40v16' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 40V20H8M56 28H32M20 8v12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM8 40h48M24 40v16', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 40V20H8M56 28H32M20 8v12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/GroundPlan.js.flow
+++ b/lib/icons3/GroundPlan.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const GroundPlan = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 40h48M24 40v16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 40V20H8M56 28H32M20 8v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 40h48M24 40v16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 40V20H8M56 28H32M20 8v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Hardwarewallet.js
+++ b/lib/icons3/Hardwarewallet.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56V40H8v16M52 40V8H12v32' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 20h8v8h-8zM36 20h8v8h-8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56V40H8v16M52 40V8H12v32', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 20h8v8h-8zM36 20h8v8h-8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Hardwarewallet.js.flow
+++ b/lib/icons3/Hardwarewallet.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Hardwarewallet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56V40H8v16M52 40V8H12v32"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h8v8h-8zM36 20h8v8h-8z"/>
+    <path fill="none" stroke="currentColor" d="M56 56V40H8v16M52 40V8H12v32" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h8v8h-8zM36 20h8v8h-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Heart.js
+++ b/lib/icons3/Heart.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Heart.js.flow
+++ b/lib/icons3/Heart.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Heart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Heart2.js
+++ b/lib/icons3/Heart2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Heart2.js.flow
+++ b/lib/icons3/Heart2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Heart2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/HexagonSpiderWeb.js
+++ b/lib/icons3/HexagonSpiderWeb.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/HexagonSpiderWeb.js.flow
+++ b/lib/icons3/HexagonSpiderWeb.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const HexagonSpiderWeb = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10"/>
+    <path fill="none" stroke="currentColor" d="M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Home.js
+++ b/lib/icons3/Home.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 24v32h48V24L32 8 8 24z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 56V36H24v20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 24v32h48V24L32 8 8 24z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 56V36H24v20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Home.js.flow
+++ b/lib/icons3/Home.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Home = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 24v32h48V24L32 8 8 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 56V36H24v20"/>
+    <path fill="none" stroke="currentColor" d="M8 24v32h48V24L32 8 8 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 56V36H24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Image.js
+++ b/lib/icons3/Image.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M8 44h8c8 0 16-8 24-8s8 8 16 8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' }),
-      _react2.default.createElement('circle', { cx: '22', cy: '22', r: '6', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M8 44h8c8 0 16-8 24-8s8 8 16 8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '22', cy: '22', r: '6', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Image.js.flow
+++ b/lib/icons3/Image.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Image = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 44h8c8 0 16-8 24-8s8 8 16 8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><circle cx="22" cy="22" r="6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 44h8c8 0 16-8 24-8s8 8 16 8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><circle cx="22" cy="22" r="6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Import.js
+++ b/lib/icons3/Import.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32l16 16 16-16M56 56H8M32 8v40' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32l16 16 16-16M56 56H8M32 8v40', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Import.js.flow
+++ b/lib/icons3/Import.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Import = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16 16 16-16M56 56H8M32 8v40"/>
+    <path fill="none" stroke="currentColor" d="M16 32l16 16 16-16M56 56H8M32 8v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Key.js
+++ b/lib/icons3/Key.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '20', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 44V32H32' })
+      _react2.default.createElement('circle', { cx: '20', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 44V32H32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Key.js.flow
+++ b/lib/icons3/Key.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Key = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="20" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 44V32H32"/>
+    <circle cx="20" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 44V32H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Keypair.js
+++ b/lib/icons3/Keypair.js
@@ -45,10 +45,10 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '20', cy: '44', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56V44H32' }),
-      _react2.default.createElement('circle', { cx: '20', cy: '20', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 32V20H32' })
+      _react2.default.createElement('circle', { cx: '20', cy: '44', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56V44H32', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '20', cy: '20', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 32V20H32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Keypair.js.flow
+++ b/lib/icons3/Keypair.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Keypair = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="20" cy="44" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56V44H32"/><circle cx="20" cy="20" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 32V20H32"/>
+    <circle cx="20" cy="44" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56V44H32" strokeWidth="4" strokeMiterlimit="10"/><circle cx="20" cy="20" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 32V20H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Layers.js
+++ b/lib/icons3/Layers.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 24L32 36 8 24l24-12 24 12z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 32l16 8-24 12L8 40l16-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 24L32 36 8 24l24-12 24 12z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 32l16 8-24 12L8 40l16-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Layers.js.flow
+++ b/lib/icons3/Layers.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Layers = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 24L32 36 8 24l24-12 24 12z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 32l16 8-24 12L8 40l16-8"/>
+    <path fill="none" stroke="currentColor" d="M56 24L32 36 8 24l24-12 24 12z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 32l16 8-24 12L8 40l16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Ledger.js
+++ b/lib/icons3/Ledger.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 24h16M8 40h48M40 40v16M24 8v48' }),
-      _react2.default.createElement('rect', { x: '8', y: '8', width: '48', height: '48', rx: '8', ry: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 24h16M8 40h48M40 40v16M24 8v48', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('rect', { x: '8', y: '8', width: '48', height: '48', rx: '8', ry: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Ledger.js.flow
+++ b/lib/icons3/Ledger.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Ledger = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 24h16M8 40h48M40 40v16M24 8v48"/><rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M8 24h16M8 40h48M40 40v16M24 8v48" strokeWidth="4" strokeMiterlimit="10"/><rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Lifebelt.js
+++ b/lib/icons3/Lifebelt.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Lifebelt.js.flow
+++ b/lib/icons3/Lifebelt.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Lifebelt = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Link.js
+++ b/lib/icons3/Link.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Link.js.flow
+++ b/lib/icons3/Link.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Link = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/LinkBroken.js
+++ b/lib/icons3/LinkBroken.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/LinkBroken.js.flow
+++ b/lib/icons3/LinkBroken.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LinkBroken = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/LinkBroken2.js
+++ b/lib/icons3/LinkBroken2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/LinkBroken2.js.flow
+++ b/lib/icons3/LinkBroken2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LinkBroken2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/List.js
+++ b/lib/icons3/List.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/List.js.flow
+++ b/lib/icons3/List.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const List = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4"/>
+    <path fill="none" stroke="currentColor" d="M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Location.js
+++ b/lib/icons3/Location.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '26.88', r: '6.88', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '26.88', r: '6.88', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Location.js.flow
+++ b/lib/icons3/Location.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Location = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="26.88" r="6.88" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="26.88" r="6.88" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/LockLocked.js
+++ b/lib/icons3/LockLocked.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '12', y: '28', width: '40', height: '28', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 48V36M20 28v-8a12 12 0 0 1 24 0v8' })
+      _react2.default.createElement('rect', { x: '12', y: '28', width: '40', height: '28', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 48V36M20 28v-8a12 12 0 0 1 24 0v8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/LockLocked.js.flow
+++ b/lib/icons3/LockLocked.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LockLocked = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 48V36M20 28v-8a12 12 0 0 1 24 0v8"/>
+    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 48V36M20 28v-8a12 12 0 0 1 24 0v8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/LockUnlocked.js
+++ b/lib/icons3/LockUnlocked.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '12', y: '28', width: '40', height: '28', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49' })
+      _react2.default.createElement('rect', { x: '12', y: '28', width: '40', height: '28', rx: '4', ry: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/LockUnlocked.js.flow
+++ b/lib/icons3/LockUnlocked.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LockUnlocked = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49"/>
+    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Magnet.js
+++ b/lib/icons3/Magnet.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Magnet.js.flow
+++ b/lib/icons3/Magnet.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Magnet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Magnet2.js
+++ b/lib/icons3/Magnet2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Magnet2.js.flow
+++ b/lib/icons3/Magnet2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Magnet2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Map.js
+++ b/lib/icons3/Map.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Map.js.flow
+++ b/lib/icons3/Map.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Map = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44"/>
+    <path fill="none" stroke="currentColor" d="M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Men.js
+++ b/lib/icons3/Men.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 8L35.31 28.69' }),
-      _react2.default.createElement('circle', { cx: '24', cy: '40', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 8h16v16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 8L35.31 28.69', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '24', cy: '40', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 8h16v16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Men.js.flow
+++ b/lib/icons3/Men.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Men = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 8L35.31 28.69"/><circle cx="24" cy="40" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 8h16v16"/>
+    <path fill="none" stroke="currentColor" d="M56 8L35.31 28.69" strokeWidth="4" strokeMiterlimit="10"/><circle cx="24" cy="40" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 8h16v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Menu.js
+++ b/lib/icons3/Menu.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32h32M16 20h32M16 44h32' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32h32M16 20h32M16 44h32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Menu.js.flow
+++ b/lib/icons3/Menu.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Menu = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32M16 20h32M16 44h32"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32M16 20h32M16 44h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Menu2.js
+++ b/lib/icons3/Menu2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8zM20 24h24M20 40h24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8zM20 24h24M20 40h24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Menu2.js.flow
+++ b/lib/icons3/Menu2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Menu2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM20 24h24M20 40h24"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM20 24h24M20 40h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Method1.js
+++ b/lib/icons3/Method1.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Method1.js.flow
+++ b/lib/icons3/Method1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16"/>
+    <path fill="none" stroke="currentColor" d="M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Method2.js
+++ b/lib/icons3/Method2.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 48H16V28M24 16h24v20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 48H16V28M24 16h24v20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Method2.js.flow
+++ b/lib/icons3/Method2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 48H16V28M24 16h24v20"/>
+    <path fill="none" stroke="currentColor" d="M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 48H16V28M24 16h24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Method3.js
+++ b/lib/icons3/Method3.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 52H8V12h40M48 40l8-8-8-8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 24l-8 8 8 8M34 22l-4 20M56 32H40' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 52H8V12h40M48 40l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 24l-8 8 8 8M34 22l-4 20M56 32H40', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Method3.js.flow
+++ b/lib/icons3/Method3.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 52H8V12h40M48 40l8-8-8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24l-8 8 8 8M34 22l-4 20M56 32H40"/>
+    <path fill="none" stroke="currentColor" d="M48 52H8V12h40M48 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24l-8 8 8 8M34 22l-4 20M56 32H40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Method4.js
+++ b/lib/icons3/Method4.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 12h40v40H16' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 12h40v40H16', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Method4.js.flow
+++ b/lib/icons3/Method4.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method4 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 12h40v40H16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16"/>
+    <path fill="none" stroke="currentColor" d="M16 12h40v40H16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Model.js
+++ b/lib/icons3/Model.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Model.js.flow
+++ b/lib/icons3/Model.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Model = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8"/>
+    <path fill="none" stroke="currentColor" d="M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ModelConnection.js
+++ b/lib/icons3/ModelConnection.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ModelConnection.js.flow
+++ b/lib/icons3/ModelConnection.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ModelConnection = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/MoreHorizontal.js
+++ b/lib/icons3/MoreHorizontal.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32h4M48 32h-4M34 32h-4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32h4M48 32h-4M34 32h-4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/MoreHorizontal.js.flow
+++ b/lib/icons3/MoreHorizontal.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const MoreHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h4M48 32h-4M34 32h-4"/>
+    <path fill="none" stroke="currentColor" d="M16 32h4M48 32h-4M34 32h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/MoreVertical.js
+++ b/lib/icons3/MoreVertical.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M30 16h4M30 32h4M30 48h4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M30 16h4M30 32h4M30 48h4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/MoreVertical.js.flow
+++ b/lib/icons3/MoreVertical.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const MoreVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M30 16h4M30 32h4M30 48h4"/>
+    <path fill="none" stroke="currentColor" d="M30 16h4M30 32h4M30 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Mouse.js
+++ b/lib/icons3/Mouse.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '16', y: '8', width: '32', height: '48', rx: '16', ry: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 16v12' })
+      _react2.default.createElement('rect', { x: '16', y: '8', width: '32', height: '48', rx: '16', ry: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 16v12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Mouse.js.flow
+++ b/lib/icons3/Mouse.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Mouse = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="16" y="8" width="32" height="48" rx="16" ry="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 16v12"/>
+    <rect x="16" y="8" width="32" height="48" rx="16" ry="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 16v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Multisigwallet.js
+++ b/lib/icons3/Multisigwallet.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 20h24v24H20zM32 8v48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 20h24v24H20zM32 8v48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Multisigwallet.js.flow
+++ b/lib/icons3/Multisigwallet.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Multisigwallet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h24v24H20zM32 8v48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h24v24H20zM32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Network.js
+++ b/lib/icons3/Network.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Network.js.flow
+++ b/lib/icons3/Network.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Network = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/NetworkDisconnected.js
+++ b/lib/icons3/NetworkDisconnected.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/NetworkDisconnected.js.flow
+++ b/lib/icons3/NetworkDisconnected.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const NetworkDisconnected = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/NetworkOk.js
+++ b/lib/icons3/NetworkOk.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M46 16L26 36l-8-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v36H8zM12 56h40M40 44v12M24 44v12', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M46 16L26 36l-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/NetworkOk.js.flow
+++ b/lib/icons3/NetworkOk.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const NetworkOk = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M46 16L26 36l-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M46 16L26 36l-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Paperclip.js
+++ b/lib/icons3/Paperclip.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Paperclip.js.flow
+++ b/lib/icons3/Paperclip.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperclip = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Paperplane.js
+++ b/lib/icons3/Paperplane.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 8L28 36M28 36l12 20L56 8 8 24l20 12z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 8L28 36M28 36l12 20L56 8 8 24l20 12z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Paperplane.js.flow
+++ b/lib/icons3/Paperplane.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperplane = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 8L28 36M28 36l12 20L56 8 8 24l20 12z"/>
+    <path fill="none" stroke="currentColor" d="M56 8L28 36M28 36l12 20L56 8 8 24l20 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Paperplane2.js
+++ b/lib/icons3/Paperplane2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M52 12L12 28l16 8 8 16 16-40z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M52 12L12 28l16 8 8 16 16-40z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Paperplane2.js.flow
+++ b/lib/icons3/Paperplane2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperplane2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 12L12 28l16 8 8 16 16-40z"/>
+    <path fill="none" stroke="currentColor" d="M52 12L12 28l16 8 8 16 16-40z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Peace.js
+++ b/lib/icons3/Peace.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Peace.js.flow
+++ b/lib/icons3/Peace.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Peace = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Pen1.js
+++ b/lib/icons3/Pen1.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Pen1.js.flow
+++ b/lib/icons3/Pen1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16"/>
+    <path fill="none" stroke="currentColor" d="M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Pen2.js
+++ b/lib/icons3/Pen2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Pen2.js.flow
+++ b/lib/icons3/Pen2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12"/>
+    <path fill="none" stroke="currentColor" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Pen3.js
+++ b/lib/icons3/Pen3.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Pen3.js.flow
+++ b/lib/icons3/Pen3.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12"/>
+    <path fill="none" stroke="currentColor" d="M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/PieChart.js
+++ b/lib/icons3/PieChart.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4', d: 'M32 8v24M56 32H32M15.03 48.97L32 32' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v24M56 32H32M15.03 48.97L32 32', strokeWidth: '4', strokeMiterlimit: '3' })
     );
   };
 

--- a/lib/icons3/PieChart.js.flow
+++ b/lib/icons3/PieChart.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PieChart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4" d="M32 8v24M56 32H32M15.03 48.97L32 32"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M32 8v24M56 32H32M15.03 48.97L32 32" strokeWidth="4" strokeMiterlimit="3"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Pin.js
+++ b/lib/icons3/Pin.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Pin.js.flow
+++ b/lib/icons3/Pin.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pin = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z"/>
+    <path fill="none" stroke="currentColor" d="M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/PlayCircle.js
+++ b/lib/icons3/PlayCircle.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 40l8-8-8-8' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 40l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/PlayCircle.js.flow
+++ b/lib/icons3/PlayCircle.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PlayCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/PlayVideo.js
+++ b/lib/icons3/PlayVideo.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('rect', { x: '8', y: '12', width: '48', height: '40', rx: '11.96', ry: '11.96', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 40l8-8-8-8' })
+      _react2.default.createElement('rect', { x: '8', y: '12', width: '48', height: '40', rx: '11.96', ry: '11.96', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 40l8-8-8-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/PlayVideo.js.flow
+++ b/lib/icons3/PlayVideo.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PlayVideo = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="12" width="48" height="40" rx="11.96" ry="11.96" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <rect x="8" y="12" width="48" height="40" rx="11.96" ry="11.96" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Print.js
+++ b/lib/icons3/Print.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 40H8V16h48v24h-8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 40H8V16h48v24h-8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Print.js.flow
+++ b/lib/icons3/Print.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Print = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40H8V16h48v24h-8"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40H8V16h48v24h-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Puzzle.js
+++ b/lib/icons3/Puzzle.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Puzzle.js.flow
+++ b/lib/icons3/Puzzle.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Puzzle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Qrcode.js
+++ b/lib/icons3/Qrcode.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 24h16v16H24z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 24h16v16H24z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Qrcode.js.flow
+++ b/lib/icons3/Qrcode.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Qrcode = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h16v16H24z"/>
+    <path fill="none" stroke="currentColor" d="M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24h16v16H24z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Record.js
+++ b/lib/icons3/Record.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Record.js.flow
+++ b/lib/icons3/Record.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Record = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Recorder.js
+++ b/lib/icons3/Recorder.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '16', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '48', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 40h32' })
+      _react2.default.createElement('circle', { cx: '16', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '48', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 40h32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Recorder.js.flow
+++ b/lib/icons3/Recorder.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Recorder = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="16" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="48" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40h32"/>
+    <circle cx="16" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="48" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Remove.js
+++ b/lib/icons3/Remove.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 32h24M8 8h48v48H8z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 32h24M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Remove.js.flow
+++ b/lib/icons3/Remove.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Remove = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 32h24M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/RemoveCircle.js
+++ b/lib/icons3/RemoveCircle.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 32h24' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 32h24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/RemoveCircle.js.flow
+++ b/lib/icons3/RemoveCircle.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const RemoveCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 32h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/RhombusNumber.js
+++ b/lib/icons3/RhombusNumber.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M24 8v48M40 8v48M56 24H8M56 40H8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M24 8v48M40 8v48M56 24H8M56 40H8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/RhombusNumber.js.flow
+++ b/lib/icons3/RhombusNumber.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const RhombusNumber = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 8v48M40 8v48M56 24H8M56 40H8"/>
+    <path fill="none" stroke="currentColor" d="M24 8v48M40 8v48M56 24H8M56 40H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Sandclock.js
+++ b/lib/icons3/Sandclock.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Sandclock.js.flow
+++ b/lib/icons3/Sandclock.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sandclock = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Save.js
+++ b/lib/icons3/Save.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 8v20H16V8M24 56V44h16v12M32 44v12' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 8v20H16V8M24 56V44h16v12M32 44v12', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Save.js.flow
+++ b/lib/icons3/Save.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Save = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 8v20H16V8M24 56V44h16v12M32 44v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 8v20H16V8M24 56V44h16v12M32 44v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Scissors.js
+++ b/lib/icons3/Scissors.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '16', cy: '20', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '16', cy: '44', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20.8 37.6L56 20M20.8 26.4L56 44' })
+      _react2.default.createElement('circle', { cx: '16', cy: '20', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '16', cy: '44', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20.8 37.6L56 20M20.8 26.4L56 44', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Scissors.js.flow
+++ b/lib/icons3/Scissors.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Scissors = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="16" cy="20" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="16" cy="44" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20.8 37.6L56 20M20.8 26.4L56 44"/>
+    <circle cx="16" cy="20" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="16" cy="44" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20.8 37.6L56 20M20.8 26.4L56 44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Search.js
+++ b/lib/icons3/Search.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56L42.14 42.14' })
+      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56L42.14 42.14', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Search.js.flow
+++ b/lib/icons3/Search.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Search2.js
+++ b/lib/icons3/Search2.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '24', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56L35.31 35.31' })
+      _react2.default.createElement('circle', { cx: '24', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56L35.31 35.31', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Search2.js.flow
+++ b/lib/icons3/Search2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="24" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L35.31 35.31"/>
+    <circle cx="24" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L35.31 35.31" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Search3.js
+++ b/lib/icons3/Search3.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M44 44L33.66 33.66' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M44 44L33.66 33.66', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Search3.js.flow
+++ b/lib/icons3/Search3.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="28" cy="28" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 44L33.66 33.66"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="28" cy="28" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M44 44L33.66 33.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Search4.js
+++ b/lib/icons3/Search4.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 56V40' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 56V40', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Search4.js.flow
+++ b/lib/icons3/Search4.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search4 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56V40"/><circle cx="32" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 56V40" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Settings.js
+++ b/lib/icons3/Settings.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Settings.js.flow
+++ b/lib/icons3/Settings.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Settings = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Shirt.js
+++ b/lib/icons3/Shirt.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Shirt.js.flow
+++ b/lib/icons3/Shirt.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Shirt = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Sign.js
+++ b/lib/icons3/Sign.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 24v32H8V8h32M24 40L56 8' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 24v32H8V8h32M24 40L56 8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Sign.js.flow
+++ b/lib/icons3/Sign.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sign = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 24v32H8V8h32M24 40L56 8"/>
+    <path fill="none" stroke="currentColor" d="M56 24v32H8V8h32M24 40L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Sign2.js
+++ b/lib/icons3/Sign2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Sign2.js.flow
+++ b/lib/icons3/Sign2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sign2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36"/>
+    <path fill="none" stroke="currentColor" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Sliders.js
+++ b/lib/icons3/Sliders.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Sliders.js.flow
+++ b/lib/icons3/Sliders.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sliders = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16"/>
+    <path fill="none" stroke="currentColor" d="M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/SmallSteeringWheel2.js
+++ b/lib/icons3/SmallSteeringWheel2.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/SmallSteeringWheel2.js.flow
+++ b/lib/icons3/SmallSteeringWheel2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const SmallSteeringWheel2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/>
+    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Spinner1.js
+++ b/lib/icons3/Spinner1.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Spinner1.js.flow
+++ b/lib/icons3/Spinner1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Spinner1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Spinner2.js
+++ b/lib/icons3/Spinner2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Spinner2.js.flow
+++ b/lib/icons3/Spinner2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Spinner2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48"/>
+    <path fill="none" stroke="currentColor" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Star.js
+++ b/lib/icons3/Star.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Star.js.flow
+++ b/lib/icons3/Star.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Star = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z"/>
+    <path fill="none" stroke="currentColor" d="M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/SteeringWheel.js
+++ b/lib/icons3/SteeringWheel.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/SteeringWheel.js.flow
+++ b/lib/icons3/SteeringWheel.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const SteeringWheel = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48"/>
+    <circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Sun.js
+++ b/lib/icons3/Sun.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Sun.js.flow
+++ b/lib/icons3/Sun.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sun = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Switch.js
+++ b/lib/icons3/Switch.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M48 12l8 8-8 8M48 36l8 8-8 8' }),
-      _react2.default.createElement('path', { d: 'M56 20H40c-12 0-12 24-24 24H8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M8 20h8c12 0 12 24 24 24h16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M48 12l8 8-8 8M48 36l8 8-8 8', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M56 20H40c-12 0-12 24-24 24H8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M8 20h8c12 0 12 24 24 24h16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Switch.js.flow
+++ b/lib/icons3/Switch.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Switch = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 12l8 8-8 8M48 36l8 8-8 8"/><path d="M56 20H40c-12 0-12 24-24 24H8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M8 20h8c12 0 12 24 24 24h16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M48 12l8 8-8 8M48 36l8 8-8 8" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 20H40c-12 0-12 24-24 24H8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M8 20h8c12 0 12 24 24 24h16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Tag.js
+++ b/lib/icons3/Tag.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M36 8L8 36l20 20 28-28V8H36z' }),
-      _react2.default.createElement('circle', { cx: '44', cy: '20', r: '4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M36 8L8 36l20 20 28-28V8H36z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '44', cy: '20', r: '4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Tag.js.flow
+++ b/lib/icons3/Tag.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Tag = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 8L8 36l20 20 28-28V8H36z"/><circle cx="44" cy="20" r="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M36 8L8 36l20 20 28-28V8H36z" strokeWidth="4" strokeMiterlimit="10"/><circle cx="44" cy="20" r="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Target.js
+++ b/lib/icons3/Target.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Target.js.flow
+++ b/lib/icons3/Target.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Target = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/TargetCross.js
+++ b/lib/icons3/TargetCross.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v8M32 48v8M56 32h-8M8 32h8' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v8M32 48v8M56 32h-8M8 32h8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/TargetCross.js.flow
+++ b/lib/icons3/TargetCross.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const TargetCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 48v8M56 32h-8M8 32h8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v8M32 48v8M56 32h-8M8 32h8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/TargetCrossSmall.js
+++ b/lib/icons3/TargetCrossSmall.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 8v16M32 40v16M56 32H40M8 32h16' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 8v16M32 40v16M56 32H40M8 32h16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/TargetCrossSmall.js.flow
+++ b/lib/icons3/TargetCrossSmall.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const TargetCrossSmall = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v16M32 40v16M56 32H40M8 32h16"/>
+    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v16M32 40v16M56 32H40M8 32h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Textfile.js
+++ b/lib/icons3/Textfile.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M12 8h40v48H12zM20 32h24M20 20h24M20 44h24' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M12 8h40v48H12zM20 32h24M20 20h24M20 44h24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Textfile.js.flow
+++ b/lib/icons3/Textfile.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Textfile = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 8h40v48H12zM20 32h24M20 20h24M20 44h24"/>
+    <path fill="none" stroke="currentColor" d="M12 8h40v48H12zM20 32h24M20 20h24M20 44h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Time.js
+++ b/lib/icons3/Time.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 44l-8-12V16' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 44l-8-12V16', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Time.js.flow
+++ b/lib/icons3/Time.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Time = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 44l-8-12V16"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 44l-8-12V16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Tire.js
+++ b/lib/icons3/Tire.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Tire.js.flow
+++ b/lib/icons3/Tire.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Tire = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Token1.js
+++ b/lib/icons3/Token1.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Token1.js.flow
+++ b/lib/icons3/Token1.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Token2.js
+++ b/lib/icons3/Token2.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Token2.js.flow
+++ b/lib/icons3/Token2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Token3.js
+++ b/lib/icons3/Token3.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Token3.js.flow
+++ b/lib/icons3/Token3.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Toolbox.js
+++ b/lib/icons3/Toolbox.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Toolbox.js.flow
+++ b/lib/icons3/Toolbox.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Toolbox = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20"/>
+    <path fill="none" stroke="currentColor" d="M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Trash.js
+++ b/lib/icons3/Trash.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Trash.js.flow
+++ b/lib/icons3/Trash.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Trash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44"/>
+    <path fill="none" stroke="currentColor" d="M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Trezor.js
+++ b/lib/icons3/Trezor.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M20 27v-7a12 12 0 0 1 24 0v7', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M20 27v-7a12 12 0 0 1 24 0v7', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Trezor.js.flow
+++ b/lib/icons3/Trezor.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Trezor = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M20 27v-7a12 12 0 0 1 24 0v7" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M20 27v-7a12 12 0 0 1 24 0v7" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Umbrella.js
+++ b/lib/icons3/Umbrella.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Umbrella.js.flow
+++ b/lib/icons3/Umbrella.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Umbrella = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/User.js
+++ b/lib/icons3/User.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '3', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' }),
+      _react2.default.createElement('path', { d: 'M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '3' })
     );
   };
 

--- a/lib/icons3/User.js.flow
+++ b/lib/icons3/User.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const User = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/>
+    <path d="M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ViewHidden.js
+++ b/lib/icons3/ViewHidden.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ViewHidden.js.flow
+++ b/lib/icons3/ViewHidden.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ViewHidden = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ViewVisible.js
+++ b/lib/icons3/ViewVisible.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { d: 'M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '8', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { d: 'M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ViewVisible.js.flow
+++ b/lib/icons3/ViewVisible.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ViewVisible = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Walletadress.js
+++ b/lib/icons3/Walletadress.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 8h48v48H8z' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 20h24v24H20z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 8h48v48H8z', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 20h24v24H20z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Walletadress.js.flow
+++ b/lib/icons3/Walletadress.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Walletadress = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h24v24H20z"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h24v24H20z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Warning.js
+++ b/lib/icons3/Warning.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 16v20M32 44v4' })
+      _react2.default.createElement('circle', { cx: '32', cy: '32', r: '24', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 16v20M32 44v4', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Warning.js.flow
+++ b/lib/icons3/Warning.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Warning = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 16v20M32 44v4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 16v20M32 44v4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Waysign.js
+++ b/lib/icons3/Waysign.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 32v24M44 32H8V8h36l12 12-12 12z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 32v24M44 32H8V8h36l12 12-12 12z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Waysign.js.flow
+++ b/lib/icons3/Waysign.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Waysign = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 32v24M44 32H8V8h36l12 12-12 12z"/>
+    <path fill="none" stroke="currentColor" d="M28 32v24M44 32H8V8h36l12 12-12 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Waysign2.js
+++ b/lib/icons3/Waysign2.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Waysign2.js.flow
+++ b/lib/icons3/Waysign2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Waysign2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32"/>
+    <path fill="none" stroke="currentColor" d="M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/WindowsLayers.js
+++ b/lib/icons3/WindowsLayers.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 44H8V8h28v20' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M20 28h36v28H20z' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 44H8V8h28v20', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M20 28h36v28H20z', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/WindowsLayers.js.flow
+++ b/lib/icons3/WindowsLayers.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const WindowsLayers = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 44H8V8h28v20"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 28h36v28H20z"/>
+    <path fill="none" stroke="currentColor" d="M20 44H8V8h28v20" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 28h36v28H20z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Women.js
+++ b/lib/icons3/Women.js
@@ -45,9 +45,9 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M8 56l20.69-20.69' }),
-      _react2.default.createElement('circle', { cx: '40', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M28 52L12 36' })
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M8 56l20.69-20.69', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('circle', { cx: '40', cy: '24', r: '16', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M28 52L12 36', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Women.js.flow
+++ b/lib/icons3/Women.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Women = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 56l20.69-20.69"/><circle cx="40" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 52L12 36"/>
+    <path fill="none" stroke="currentColor" d="M8 56l20.69-20.69" strokeWidth="4" strokeMiterlimit="10"/><circle cx="40" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 52L12 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Women2.js
+++ b/lib/icons3/Women2.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '32', cy: '22', r: '14', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M32 36v24M40 48H24' })
+      _react2.default.createElement('circle', { cx: '32', cy: '22', r: '14', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M32 36v24M40 48H24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Women2.js.flow
+++ b/lib/icons3/Women2.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Women2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="22" r="14" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 36v24M40 48H24"/>
+    <circle cx="32" cy="22" r="14" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 36v24M40 48H24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/Wrench.js
+++ b/lib/icons3/Wrench.js
@@ -45,7 +45,7 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('path', { d: 'M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' })
+      _react2.default.createElement('path', { d: 'M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/Wrench.js.flow
+++ b/lib/icons3/Wrench.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Wrench = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ZoomIn.js
+++ b/lib/icons3/ZoomIn.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56L42.14 42.14M16 28h24M28 16v24' })
+      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56L42.14 42.14M16 28h24M28 16v24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ZoomIn.js.flow
+++ b/lib/icons3/ZoomIn.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ZoomIn = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14M16 28h24M28 16v24"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14M16 28h24M28 16v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/lib/icons3/ZoomOut.js
+++ b/lib/icons3/ZoomOut.js
@@ -45,8 +45,8 @@
     return _react2.default.createElement(
       _SvgIcon2.default,
       _extends({}, props, { viewBox: '0 0 64 64' }),
-      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4' }),
-      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', 'stroke-miterlimit': '10', 'stroke-width': '4', d: 'M56 56L42.14 42.14M16 28h24' })
+      _react2.default.createElement('circle', { cx: '28', cy: '28', r: '20', fill: 'none', stroke: 'currentColor', strokeWidth: '4', strokeMiterlimit: '10' }),
+      _react2.default.createElement('path', { fill: 'none', stroke: 'currentColor', d: 'M56 56L42.14 42.14M16 28h24', strokeWidth: '4', strokeMiterlimit: '10' })
     );
   };
 

--- a/lib/icons3/ZoomOut.js.flow
+++ b/lib/icons3/ZoomOut.js.flow
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ZoomOut = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14M16 28h24"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14M16 28h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/scripts/svg-build-optimize.js
+++ b/scripts/svg-build-optimize.js
@@ -77,6 +77,48 @@ const svgo = new SVGO({
         },
       },
     },
+    {
+      replaceStrokeWidthForReact: {
+        type: 'full', // full, perItem or perItemReverse
+        description: 'uses strokeWidth instead of stroke-width to appease react',
+        parmas: {}, // arbitrary data
+        fn(data) {
+          const elems = findStrokeElements(data);
+          elems.forEach((elem) => {
+            const { value } = elem.attr('stroke-width'); // eslint-disable-line no-param-reassign
+            elem.addAttr({
+              name: 'strokeWidth',
+              prefix: '',
+              local: 'strokeWidth',
+              value,
+            });
+            elem.removeAttr('stroke-width');
+          });
+          return data;
+        },
+      },
+    },
+    {
+      replaceStrokeMiterLimitForReact: {
+        type: 'full', // full, perItem or perItemReverse
+        description: 'uses strokeMiterLimit instead of stroke-miterlimit to appease react',
+        parmas: {}, // arbitrary data
+        fn(data) {
+          const elems = findStrokeElements(data);
+          elems.forEach((elem) => {
+            const { value } = elem.attr('stroke-miterlimit'); // eslint-disable-line no-param-reassign
+            elem.addAttr({
+              name: 'strokeMiterlimit',
+              prefix: '',
+              local: 'strokeMiterlimit',
+              value,
+            });
+            elem.removeAttr('stroke-miterlimit');
+          });
+          return data;
+        },
+      },
+    },
   ]),
 });
 

--- a/src/icons3/Add.js
+++ b/src/icons3/Add.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Add = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M32 20v24M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 32h24M32 20v24M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/AddCircle.js
+++ b/src/icons3/AddCircle.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const AddCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M32 20v24"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 32h24M32 20v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/AppleCommand.js
+++ b/src/icons3/AppleCommand.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const AppleCommand = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z"/>
+    <path fill="none" stroke="currentColor" d="M24 24h16v16H24zM48 8a8 8 0 0 1 8 8 8 8 0 0 1-8 8h-8v-8a8 8 0 0 1 8-8zM40 40h8a8 8 0 0 1 8 8 8 8 0 0 1-8 8 8 8 0 0 1-8-8v-8zM16 40h8v8a8 8 0 0 1-8 8 8 8 0 0 1-8-8 8 8 0 0 1 8-8zM16 8a8 8 0 0 1 8 8v8h-8a8 8 0 0 1-8-8 8 8 0 0 1 8-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowDown.js
+++ b/src/icons3/ArrowDown.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowDown = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 44l8 8 8-8M32 12v40"/>
+    <path fill="none" stroke="currentColor" d="M24 44l8 8 8-8M32 12v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowDownBoxed.js
+++ b/src/icons3/ArrowDownBoxed.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowDownBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 28l8 8 8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M24 28l8 8 8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowLeft.js
+++ b/src/icons3/ArrowLeft.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowLeft = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 24l-8 8 8 8M52 32H12"/>
+    <path fill="none" stroke="currentColor" d="M20 24l-8 8 8 8M52 32H12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowLeftBoxed.js
+++ b/src/icons3/ArrowLeftBoxed.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowLeftBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 24l-8 8 8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M36 24l-8 8 8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowRight.js
+++ b/src/icons3/ArrowRight.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowRight = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 40l8-8-8-8M52 32H12"/>
+    <path fill="none" stroke="currentColor" d="M44 40l8-8-8-8M52 32H12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowRightBoxed.js
+++ b/src/icons3/ArrowRightBoxed.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowRightBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowUp.js
+++ b/src/icons3/ArrowUp.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowUp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 20l-8-8-8 8M32 12v40"/>
+    <path fill="none" stroke="currentColor" d="M40 20l-8-8-8 8M32 12v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ArrowUpBoxed.js
+++ b/src/icons3/ArrowUpBoxed.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ArrowUpBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 36l-8-8-8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M40 36l-8-8-8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Back.js
+++ b/src/icons3/Back.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Back = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 52L20 32l20-20"/>
+    <path fill="none" stroke="currentColor" d="M40 52L20 32l20-20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Ball.js
+++ b/src/icons3/Ball.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Ball = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M46 51.49a24 24 0 0 1 0-39M18 12.51a24 24 0 0 1 0 39M8 32h48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BarChart.js
+++ b/src/icons3/BarChart.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BarChart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56H8V36M20 20v36M32 32v24M44 8v48"/>
+    <path fill="none" stroke="currentColor" d="M56 56H8V36M20 20v36M32 32v24M44 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Battery100.js
+++ b/src/icons3/Battery100.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery100 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16M40 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Battery25.js
+++ b/src/icons3/Battery25.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery25 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Battery50.js
+++ b/src/icons3/Battery50.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery50 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Battery75.js
+++ b/src/icons3/Battery75.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Battery75 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8zM16 24v16M24 24v16M32 24v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BatteryEmpty.js
+++ b/src/icons3/BatteryEmpty.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BatteryEmpty = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24v-8H8v32h40v-8h8V24h-8z"/>
+    <path fill="none" stroke="currentColor" d="M48 24v-8H8v32h40v-8h8V24h-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Block.js
+++ b/src/icons3/Block.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Block = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20v24l24 12 24-12V20L32 8 8 20z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20L32 32 8 20M32 32v24"/>
+    <path fill="none" stroke="currentColor" d="M8 20v24l24 12 24-12V20L32 8 8 20z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 20L32 32 8 20M32 32v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Block3d.js
+++ b/src/icons3/Block3d.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Block3d = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24"/>
+    <path fill="none" stroke="currentColor" d="M8 20v24l24 12 24-12V20L32 8 8 20zM32 32l24-12M32 56V32M56 44L32 32M8 44l24-12M8 20l24 12M32 8v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Bluetooth.js
+++ b/src/icons3/Bluetooth.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Bluetooth = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 40l20-16-12-12v40l12-12-20-16"/>
+    <path fill="none" stroke="currentColor" d="M20 40l20-16-12-12v40l12-12-20-16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Book.js
+++ b/src/icons3/Book.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Book = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44"/>
+    <path fill="none" stroke="currentColor" d="M32 56l24-4V8l-24 4L8 8v44l24 4zM32 12v44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Box.js
+++ b/src/icons3/Box.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Box = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxContainer.js
+++ b/src/icons3/BoxContainer.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxContainer = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 8h32l8 16v32H8V24l8-16zM8 24h48"/>
+    <path fill="none" stroke="currentColor" d="M16 8h32l8 16v32H8V24l8-16zM8 24h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitBackslash.js
+++ b/src/icons3/BoxSplitBackslash.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitBackslash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 56L8 8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 56L8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitCross.js
+++ b/src/icons3/BoxSplitCross.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 8L8 56M56 56L8 8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 8L8 56M56 56L8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitHorizontal.js
+++ b/src/icons3/BoxSplitHorizontal.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 32h48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitHorizontalVertical.js
+++ b/src/icons3/BoxSplitHorizontalVertical.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitHorizontalVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM32 56V8M8 32h48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM32 56V8M8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitSlash.js
+++ b/src/icons3/BoxSplitSlash.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitSlash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM56 8L8 56"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM56 8L8 56" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxSplitVertical.js
+++ b/src/icons3/BoxSplitVertical.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxSplitVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM32 56V8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM32 56V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxedExport.js
+++ b/src/icons3/BoxedExport.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxedExport = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 32v24H8V12h24M56 24V8H40M36 28L56 8"/>
+    <path fill="none" stroke="currentColor" d="M52 32v24H8V12h24M56 24V8H40M36 28L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/BoxedImport.js
+++ b/src/icons3/BoxedImport.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const BoxedImport = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 40v16H8V12h16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 12v16h16M56 8L36 28"/>
+    <path fill="none" stroke="currentColor" d="M52 40v16H8V12h16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M36 12v16h16M56 8L36 28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Browser.js
+++ b/src/icons3/Browser.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Browser = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 24h48M48 16h-4M40 16h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Bulp.js
+++ b/src/icons3/Bulp.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Bulp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 48h16c0-8 8-12 8-24a16 16 0 0 0-32 0c0 12 8 16 8 24zM40 56H24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Camera.js
+++ b/src/icons3/Camera.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Camera = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="20" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 20l4-12h24l4 12"/><circle cx="32" cy="38" r="10" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <rect x="8" y="20" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 20l4-12h24l4 12" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="38" r="10" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Chat.js
+++ b/src/icons3/Chat.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Chat = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 52V18.58A6.58 6.58 0 0 1 14.58 12h34.84A6.58 6.58 0 0 1 56 18.58v22.84A6.58 6.58 0 0 1 49.42 48H16zM16 24h32M16 36h32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Check1.js
+++ b/src/icons3/Check1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Check1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2"/>
+    <path fill="none" stroke="currentColor" d="M44 24L28 40l-8-8M55.8 35.13A24 24 0 1 1 35.13 8.2" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Check2.js
+++ b/src/icons3/Check2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Check2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 24L28 40l-8-8"/>
+    <path fill="none" stroke="currentColor" d="M44 24L28 40l-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Checkmark.js
+++ b/src/icons3/Checkmark.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Checkmark = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 28l16 16 24-24"/>
+    <path fill="none" stroke="currentColor" d="M12 28l16 16 24-24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Circle.js
+++ b/src/icons3/Circle.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Circle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitBackslash.js
+++ b/src/icons3/CircleSplitBackslash.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitBackslash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 15.04l33.93 33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 15.04l33.93 33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitCross.js
+++ b/src/icons3/CircleSplitCross.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 48.97l33.93-33.93M15.03 15.04l33.93 33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitHorizontal.js
+++ b/src/icons3/CircleSplitHorizontal.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 32h48"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 32h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitHorizontalVertical.js
+++ b/src/icons3/CircleSplitHorizontalVertical.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitHorizontalVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M56 32H8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48M56 32H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitSlash.js
+++ b/src/icons3/CircleSplitSlash.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitSlash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M15.03 48.97l33.93-33.93"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M15.03 48.97l33.93-33.93" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CircleSplitVertical.js
+++ b/src/icons3/CircleSplitVertical.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CircleSplitVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Cli.js
+++ b/src/icons3/Cli.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Cli = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 40l8-8-8-8M32 40h12"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 40l8-8-8-8M32 40h12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Close.js
+++ b/src/icons3/Close.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Close = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 16l32 32M48 16L16 48"/>
+    <path fill="none" stroke="currentColor" d="M16 16l32 32M48 16L16 48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CloseBoxed.js
+++ b/src/icons3/CloseBoxed.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CloseBoxed = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20l24 24M44 20L20 44M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 20l24 24M44 20L20 44M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Code.js
+++ b/src/icons3/Code.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Code = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48"/>
+    <path fill="none" stroke="currentColor" d="M16 48L8 32l8-16M48 48l8-16-8-16M36 8l-8 48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Coffee.js
+++ b/src/icons3/Coffee.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Coffee = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 24h40v24a8 8 0 0 1-8 8H16a8 8 0 0 1-8-8V24zM28 16V8M16 16V8M40 16V8M48 44h5.42A2.58 2.58 0 0 0 56 41.42v-6.84A2.58 2.58 0 0 0 53.42 32H48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Compass.js
+++ b/src/icons3/Compass.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Compass = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 28l-4 12 12-4 4-12-12 4z"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 28l-4 12 12-4 4-12-12 4z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Contract.js
+++ b/src/icons3/Contract.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contract = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 40l8-8-8-8M24 24l-8 8 8 8M34 22l-4 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Contractabi.js
+++ b/src/icons3/Contractabi.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractabi = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20"/>
+    <path fill="none" stroke="currentColor" d="M8 8h36v48H8zM44 52h12V12H44M16 20h20M36 32H16M16 44h20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Contractexecute1.js
+++ b/src/icons3/Contractexecute1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56V24h32"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48l8-8-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 56V24h32" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M36 48l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Contractexecute2.js
+++ b/src/icons3/Contractexecute2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48l8-8-8-8"/><circle cx="40" cy="40" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4"/>
+    <path fill="none" stroke="currentColor" d="M36 48l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><circle cx="40" cy="40" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40H8V8h44v8M16 16v4M24 16v4M32 16v4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Contractexecute3.js
+++ b/src/icons3/Contractexecute3.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Contractexecute3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Copytoclipboard.js
+++ b/src/icons3/Copytoclipboard.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Copytoclipboard = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 40H8V8h32v16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h32v32H24z"/>
+    <path fill="none" stroke="currentColor" d="M24 40H8V8h32v16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24h32v32H24z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Crop.js
+++ b/src/icons3/Crop.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Crop = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 48H16V8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 16h40v40M8 56L56 8"/>
+    <path fill="none" stroke="currentColor" d="M56 48H16V8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 16h40v40M8 56L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Crosscursor.js
+++ b/src/icons3/Crosscursor.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Crosscursor = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8"/>
+    <path fill="none" stroke="currentColor" d="M32 8v48M56 32H8M40 16l-8-8-8 8M24 48l8 8 8-8M48 40l8-8-8-8M16 24l-8 8 8 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyBtc.js
+++ b/src/icons3/CurrencyBtc.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyBtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M12 16h32a8 8 0 0 1 8 8 8 8 0 0 1-8 8H28M20 32h24a8 8 0 0 1 8 8 8 8 0 0 1-8 8H12M20 8v48M40 8v8M40 48v8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyEtc.js
+++ b/src/icons3/CurrencyEtc.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyEtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16-8 16 8M16 32l16 8 16-8"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16-8 16 8M16 32l16 8 16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyEth.js
+++ b/src/icons3/CurrencyEth.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyEth = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16 8 16-8M32 8v48"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16 8 16-8M32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyLtc.js
+++ b/src/icons3/CurrencyLtc.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyLtc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 16l-8 32h24M36 28l-20 8"/>
+    <path fill="none" stroke="currentColor" d="M28 16l-8 32h24M36 28l-20 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyUsd.js
+++ b/src/icons3/CurrencyUsd.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyUsd = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M28 32a8 8 0 0 1 0-16M36 32a8 8 0 0 1 0 16M32 8v8M32 48v8M28 32h8M44 20s-4-4-8-4h-8M20 44s4 4 8 4h8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyXmr.js
+++ b/src/icons3/CurrencyXmr.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyXmr = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 48h-8V16L32 32 16 16v32H8"/>
+    <path fill="none" stroke="currentColor" d="M56 48h-8V16L32 32 16 16v32H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/CurrencyZec.js
+++ b/src/icons3/CurrencyZec.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const CurrencyZec = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 16h28L20 48h28M32 8v8M32 48v8"/>
+    <path fill="none" stroke="currentColor" d="M16 16h28L20 48h28M32 8v8M32 48v8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Dashboard.js
+++ b/src/icons3/Dashboard.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Dashboard = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03L32 32M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Database.js
+++ b/src/icons3/Database.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Database = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 16v32c0 4.42-10.75 8-24 8S8 52.42 8 48V16c0-4.42 10.75-8 24-8s24 3.58 24 8z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 16c0 4.42-10.75 8-24 8S8 20.42 8 16M56 32c0 4.42-10.75 8-24 8S8 36.42 8 32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Disk.js
+++ b/src/icons3/Disk.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Disk = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M38 32h18M8 32h18.01M48.97 15.03L36.21 27.79M27.76 36.24L15.03 48.97" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Display.js
+++ b/src/icons3/Display.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Display = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="8" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 56h32M28 44l-4 12M36 44l4 12M8 36h48"/>
+    <rect x="8" y="8" width="48" height="36" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 56h32M28 44l-4 12M36 44l4 12M8 36h48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/DoorEnter.js
+++ b/src/icons3/DoorEnter.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DoorEnter = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 20V8h32v48H16V44"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8M8 32h28"/>
+    <path fill="none" stroke="currentColor" d="M16 20V8h32v48H16V44" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8M8 32h28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/DoorExit.js
+++ b/src/icons3/DoorExit.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DoorExit = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28"/>
+    <path fill="none" stroke="currentColor" d="M40 44v12H8V8h32v12M48 40l8-8-8-8M28 32h28" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Download.js
+++ b/src/icons3/Download.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Download = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4"/>
+    <path fill="none" stroke="currentColor" d="M8 40h48v16H8zM24 24l8 8 8-8M32 8v24M16 48h4M24 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Drop.js
+++ b/src/icons3/Drop.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Drop = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 36.8C52 17.6 32 8 32 8s-20 9.6-20 28.8C12 47.4 21 56 32 56s20-8.6 20-19.2zM22 36.8a9.81 9.81 0 0 0 10 9.6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/DropdownArrowDown.js
+++ b/src/icons3/DropdownArrowDown.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DropdownArrowDown = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24L32 40 16 24"/>
+    <path fill="none" stroke="currentColor" d="M48 24L32 40 16 24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/DropdownArrowUp.js
+++ b/src/icons3/DropdownArrowUp.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const DropdownArrowUp = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40l16-16 16 16"/>
+    <path fill="none" stroke="currentColor" d="M16 40l16-16 16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Education.js
+++ b/src/icons3/Education.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Education = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 36L8 24l24-12 24 12-24 12z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 28v24H16V28M56 24v20"/>
+    <path fill="none" stroke="currentColor" d="M32 36L8 24l24-12 24 12-24 12z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 28v24H16V28M56 24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Email.js
+++ b/src/icons3/Email.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Email = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 12h48v40H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20L32 36 8 20"/>
+    <path fill="none" stroke="currentColor" d="M8 12h48v40H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 20L32 36 8 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/EmailOpen.js
+++ b/src/icons3/EmailOpen.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmailOpen = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 20l-24-8-24 8v32h48V20z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 28l-16 8-16-8"/>
+    <path fill="none" stroke="currentColor" d="M56 20l-24-8-24 8v32h48V20z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 28l-16 8-16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/EmoteHappy.js
+++ b/src/icons3/EmoteHappy.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmoteHappy = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M40.49 40a12 12 0 0 1-17 0" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h-4M28 24h-4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M40.49 40a12 12 0 0 1-17 0" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M40 24h-4M28 24h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/EmoteSad.js
+++ b/src/icons3/EmoteSad.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EmoteSad = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M23.51 43.51a12 12 0 0 1 17 0" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h-4M28 24h-4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M23.51 43.51a12 12 0 0 1 17 0" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M40 24h-4M28 24h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Etc.js
+++ b/src/icons3/Etc.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Etc = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16-8 16 8M16 32l16 8 16-8"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 32l16-8 16 8M16 32l16 8 16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/EtcSimple.js
+++ b/src/icons3/EtcSimple.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const EtcSimple = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56L16 32 32 8l16 24-16 24zM16 32h32"/>
+    <path fill="none" stroke="currentColor" d="M32 56L16 32 32 8l16 24-16 24zM16 32h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Export.js
+++ b/src/icons3/Export.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Export = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 24L32 8 16 24M56 56H8M32 48V8"/>
+    <path fill="none" stroke="currentColor" d="M48 24L32 8 16 24M56 56H8M32 48V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/File.js
+++ b/src/icons3/File.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const File = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 8h40v48H12z"/>
+    <path fill="none" stroke="currentColor" d="M12 8h40v48H12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Flag.js
+++ b/src/icons3/Flag.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Flag = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32L36 20 48 8H16v48"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32L36 20 48 8H16v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Folder.js
+++ b/src/icons3/Folder.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Folder = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 20l-4-8H8v40h48V20H28z"/>
+    <path fill="none" stroke="currentColor" d="M28 20l-4-8H8v40h48V20H28z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Forward.js
+++ b/src/icons3/Forward.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Forward = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 12l20 20-20 20"/>
+    <path fill="none" stroke="currentColor" d="M24 12l20 20-20 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/FullscreenExpand.js
+++ b/src/icons3/FullscreenExpand.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const FullscreenExpand = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 48h12V36M28 16H16v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM16 16l12 12M48 48L36 36"/>
+    <path fill="none" stroke="currentColor" d="M36 48h12V36M28 16H16v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8zM16 16l12 12M48 48L36 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/FullscreenShrink.js
+++ b/src/icons3/FullscreenShrink.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const FullscreenShrink = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 36H36v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM36 36l12 12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 28h12V16M28 28L16 16"/>
+    <path fill="none" stroke="currentColor" d="M48 36H36v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8zM36 36l12 12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 28h12V16M28 28L16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Game.js
+++ b/src/icons3/Game.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Game = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 56l-8-4-8 4-8-4-8 4-8-4-8 4V32A24 24 0 0 1 32 8a24 24 0 0 1 24 24zM24 28v4M40 28v4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Globe.js
+++ b/src/icons3/Globe.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Globe = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 19.17a39.81 39.81 0 0 1-20 5.33 39.81 39.81 0 0 1-20-5.33M12 44.88a40 40 0 0 1 39.92 0M29 56a40 40 0 0 1 0-48M35 8a40 40 0 0 1 0 48" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/GroundPlan.js
+++ b/src/icons3/GroundPlan.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const GroundPlan = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM8 40h48M24 40v16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 40V20H8M56 28H32M20 8v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM8 40h48M24 40v16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 40V20H8M56 28H32M20 8v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Hardwarewallet.js
+++ b/src/icons3/Hardwarewallet.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Hardwarewallet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56V40H8v16M52 40V8H12v32"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h8v8h-8zM36 20h8v8h-8z"/>
+    <path fill="none" stroke="currentColor" d="M56 56V40H8v16M52 40V8H12v32" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h8v8h-8zM36 20h8v8h-8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Heart.js
+++ b/src/icons3/Heart.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Heart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M44 12c-8 0-9.91 8-12 8s-4-8-12-8c-6.63 0-12 4-12 12 0 12 20 28 24 28s24-16 24-28c0-8-5.37-12-12-12z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Heart2.js
+++ b/src/icons3/Heart2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Heart2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M35.54 15.44L32 19l-3.54-3.54A11.67 11.67 0 0 0 12 31.94l3.54 3.54 8.25 8.25L32 52l8.25-8.25 8.25-8.25 3.5-3.56a11.67 11.67 0 0 0-16.5-16.5z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/HexagonSpiderWeb.js
+++ b/src/icons3/HexagonSpiderWeb.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const HexagonSpiderWeb = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10"/>
+    <path fill="none" stroke="currentColor" d="M20 54L8 32l12-22h24l12 22-12 22H20zM32 32l12-22M32 32h24M32 32l12 22M32 32L20 54M32 32H8M32 32L20 10" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Home.js
+++ b/src/icons3/Home.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Home = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 24v32h48V24L32 8 8 24z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 56V36H24v20"/>
+    <path fill="none" stroke="currentColor" d="M8 24v32h48V24L32 8 8 24z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 56V36H24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Image.js
+++ b/src/icons3/Image.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Image = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M8 44h8c8 0 16-8 24-8s8 8 16 8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><circle cx="22" cy="22" r="6" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M8 44h8c8 0 16-8 24-8s8 8 16 8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><circle cx="22" cy="22" r="6" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Import.js
+++ b/src/icons3/Import.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Import = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32l16 16 16-16M56 56H8M32 8v40"/>
+    <path fill="none" stroke="currentColor" d="M16 32l16 16 16-16M56 56H8M32 8v40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Key.js
+++ b/src/icons3/Key.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Key = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="20" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 44V32H32"/>
+    <circle cx="20" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 44V32H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Keypair.js
+++ b/src/icons3/Keypair.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Keypair = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="20" cy="44" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56V44H32"/><circle cx="20" cy="20" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 32V20H32"/>
+    <circle cx="20" cy="44" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56V44H32" strokeWidth="4" strokeMiterlimit="10"/><circle cx="20" cy="20" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 32V20H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Layers.js
+++ b/src/icons3/Layers.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Layers = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 24L32 36 8 24l24-12 24 12z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 32l16 8-24 12L8 40l16-8"/>
+    <path fill="none" stroke="currentColor" d="M56 24L32 36 8 24l24-12 24 12z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 32l16 8-24 12L8 40l16-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Ledger.js
+++ b/src/icons3/Ledger.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Ledger = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 24h16M8 40h48M40 40v16M24 8v48"/><rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M8 24h16M8 40h48M40 40v16M24 8v48" strokeWidth="4" strokeMiterlimit="10"/><rect x="8" y="8" width="48" height="48" rx="8" ry="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Lifebelt.js
+++ b/src/icons3/Lifebelt.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Lifebelt = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48.97 48.97L37.66 37.66M26.34 26.34L15.03 15.03M37.66 26.34l11.31-11.31M26.34 37.66L15.03 48.97" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Link.js
+++ b/src/icons3/Link.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Link = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M28 44h-8A12 12 0 0 1 8 32a12 12 0 0 1 12-12h8M36 20h8a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-8M20 32h24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/LinkBroken.js
+++ b/src/icons3/LinkBroken.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LinkBroken = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M32 16v32" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/LinkBroken2.js
+++ b/src/icons3/LinkBroken2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LinkBroken2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 44h-4A12 12 0 0 1 8 32a12 12 0 0 1 12-12h4M40 20h4a12 12 0 0 1 12 12 12 12 0 0 1-12 12h-4M24 12l-4-4M40 12l4-4M24 52l-4 4M40 52l4 4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/List.js
+++ b/src/icons3/List.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const List = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4"/>
+    <path fill="none" stroke="currentColor" d="M20 16h36M20 32h36M20 48h36M8 16h4M8 32h4M8 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Location.js
+++ b/src/icons3/Location.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Location = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="26.88" r="6.88" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M12 27.2C12 46.4 32 56 32 56s20-9.6 20-28.8C52 16.6 43 8 32 8s-20 8.6-20 19.2z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="26.88" r="6.88" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/LockLocked.js
+++ b/src/icons3/LockLocked.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LockLocked = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 48V36M20 28v-8a12 12 0 0 1 24 0v8"/>
+    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 48V36M20 28v-8a12 12 0 0 1 24 0v8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/LockUnlocked.js
+++ b/src/icons3/LockUnlocked.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const LockUnlocked = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49"/>
+    <rect x="12" y="28" width="40" height="28" rx="4" ry="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 48V36M20 28v-8a12 12 0 0 1 20.49-8.49" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Magnet.js
+++ b/src/icons3/Magnet.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Magnet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 8H40v24a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H8v24a24 24 0 0 0 24 24 24 24 0 0 0 24-24zM24 20H8M40 20h16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Magnet2.js
+++ b/src/icons3/Magnet2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Magnet2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M52 8H40v28a8 8 0 0 1-8 8 8 8 0 0 1-8-8V8H12v28a20 20 0 0 0 20 20 20 20 0 0 0 20-20zM24 20H12M40 20h12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Map.js
+++ b/src/icons3/Map.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Map = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44"/>
+    <path fill="none" stroke="currentColor" d="M24 56l16-4 16 4V12L40 8l-16 4L8 8v44l16 4zM24 12v44M40 8v44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Men.js
+++ b/src/icons3/Men.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Men = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 8L35.31 28.69"/><circle cx="24" cy="40" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 8h16v16"/>
+    <path fill="none" stroke="currentColor" d="M56 8L35.31 28.69" strokeWidth="4" strokeMiterlimit="10"/><circle cx="24" cy="40" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 8h16v16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Menu.js
+++ b/src/icons3/Menu.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Menu = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32M16 20h32M16 44h32"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32M16 20h32M16 44h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Menu2.js
+++ b/src/icons3/Menu2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Menu2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8zM20 24h24M20 40h24"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8zM20 24h24M20 40h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Method1.js
+++ b/src/icons3/Method1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16"/>
+    <path fill="none" stroke="currentColor" d="M44 8v20H20V8M40 48l-8 8-8-8M32 28v28M48 56h8V16M16 56H8V16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Method2.js
+++ b/src/icons3/Method2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 48H16V28M24 16h24v20"/>
+    <path fill="none" stroke="currentColor" d="M8 8h16v16H8zM40 40h16v16H40zM56 28l-8 8-8-8M8 36l8-8 8 8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 48H16V28M24 16h24v20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Method3.js
+++ b/src/icons3/Method3.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 52H8V12h40M48 40l8-8-8-8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24l-8 8 8 8M34 22l-4 20M56 32H40"/>
+    <path fill="none" stroke="currentColor" d="M48 52H8V12h40M48 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24l-8 8 8 8M34 22l-4 20M56 32H40" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Method4.js
+++ b/src/icons3/Method4.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Method4 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 12h40v40H16"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16"/>
+    <path fill="none" stroke="currentColor" d="M16 12h40v40H16" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 40l8-8-8-8M16 24l-8 8 8 8M34 22l-4 20M8 32h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Model.js
+++ b/src/icons3/Model.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Model = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8"/>
+    <path fill="none" stroke="currentColor" d="M8 40h16v16H8zM40 40h16v16H40zM24 8h16v16H24zM48 40v-8H16v8M32 32v-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ModelConnection.js
+++ b/src/icons3/ModelConnection.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ModelConnection = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24 20v4c0 12 16 4 16 16v4M24 44h32v12H24zM8 8h32v12H8z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/MoreHorizontal.js
+++ b/src/icons3/MoreHorizontal.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const MoreHorizontal = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h4M48 32h-4M34 32h-4"/>
+    <path fill="none" stroke="currentColor" d="M16 32h4M48 32h-4M34 32h-4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/MoreVertical.js
+++ b/src/icons3/MoreVertical.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const MoreVertical = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M30 16h4M30 32h4M30 48h4"/>
+    <path fill="none" stroke="currentColor" d="M30 16h4M30 32h4M30 48h4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Mouse.js
+++ b/src/icons3/Mouse.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Mouse = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="16" y="8" width="32" height="48" rx="16" ry="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 16v12"/>
+    <rect x="16" y="8" width="32" height="48" rx="16" ry="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 16v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Multisigwallet.js
+++ b/src/icons3/Multisigwallet.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Multisigwallet = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h24v24H20zM32 8v48"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h24v24H20zM32 8v48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Network.js
+++ b/src/icons3/Network.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Network = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/NetworkDisconnected.js
+++ b/src/icons3/NetworkDisconnected.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const NetworkDisconnected = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12M22 16l20 20M42 16L22 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/NetworkOk.js
+++ b/src/icons3/NetworkOk.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const NetworkOk = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M46 16L26 36l-8-8"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v36H8zM12 56h40M40 44v12M24 44v12" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M46 16L26 36l-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Paperclip.js
+++ b/src/icons3/Paperclip.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperclip = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M54.35 31.22L32.94 50.75a13.65 13.65 0 0 1-19.3-19.3l21.41-19.53a9.1 9.1 0 1 1 12.87 12.87L26.51 44.31a4.55 4.55 0 0 1-6.43-6.43l21.45-19.57" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Paperplane.js
+++ b/src/icons3/Paperplane.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperplane = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 8L28 36M28 36l12 20L56 8 8 24l20 12z"/>
+    <path fill="none" stroke="currentColor" d="M56 8L28 36M28 36l12 20L56 8 8 24l20 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Paperplane2.js
+++ b/src/icons3/Paperplane2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Paperplane2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 12L12 28l16 8 8 16 16-40z"/>
+    <path fill="none" stroke="currentColor" d="M52 12L12 28l16 8 8 16 16-40z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Peace.js
+++ b/src/icons3/Peace.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Peace = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v48M32 32L15.05 48.95M48.97 48.97L32 32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Pen1.js
+++ b/src/icons3/Pen1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16"/>
+    <path fill="none" stroke="currentColor" d="M24 56l32-32L40 8 8 40v16h16zM8 40l16 16M32 16l16 16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Pen2.js
+++ b/src/icons3/Pen2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12"/>
+    <path fill="none" stroke="currentColor" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Pen3.js
+++ b/src/icons3/Pen3.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pen3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12"/>
+    <path fill="none" stroke="currentColor" d="M24 52l32-32L44 8 12 40 8 56l16-4zM12 40l12 12M36 16l12 12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/PieChart.js
+++ b/src/icons3/PieChart.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PieChart = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4" d="M32 8v24M56 32H32M15.03 48.97L32 32"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path fill="none" stroke="currentColor" d="M32 8v24M56 32H32M15.03 48.97L32 32" strokeWidth="4" strokeMiterlimit="3"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Pin.js
+++ b/src/icons3/Pin.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Pin = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z"/>
+    <path fill="none" stroke="currentColor" d="M8 56l16-16M52 28l4-4-4-4-8-8-4-4-4 4a5.66 5.66 0 0 0 0 8l-8 8a11.31 11.31 0 0 0-16 0l23.94 24.13L36 52a11.36 11.36 0 0 0 0-16l8-8a5.66 5.66 0 0 0 8 0z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/PlayCircle.js
+++ b/src/icons3/PlayCircle.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PlayCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/PlayVideo.js
+++ b/src/icons3/PlayVideo.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const PlayVideo = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <rect x="8" y="12" width="48" height="40" rx="11.96" ry="11.96" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 40l8-8-8-8"/>
+    <rect x="8" y="12" width="48" height="40" rx="11.96" ry="11.96" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 40l8-8-8-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Print.js
+++ b/src/icons3/Print.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Print = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40H8V16h48v24h-8"/>
+    <path fill="none" stroke="currentColor" d="M16 32h32v24H16zM24 48h16M24 40h16M20 16V8h24v8" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40H8V16h48v24h-8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Puzzle.js
+++ b/src/icons3/Puzzle.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Puzzle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M48 28V12H36c0 2.21 4 8-4 8s-4-5.79-4-8H16v16c-2.21 0-8-4-8 4s5.79 4 8 4v16h12c0-2.21-4-8 4-8s4 5.79 4 8h12V36c2.21 0 8 4 8-4s-5.79-4-8-4z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Qrcode.js
+++ b/src/icons3/Qrcode.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Qrcode = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 24h16v16H24z"/>
+    <path fill="none" stroke="currentColor" d="M16 56H8v-8M56 48v8h-8M48 8h8v8M8 16V8h8M16 16h32v32H16z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M24 24h16v16H24z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Record.js
+++ b/src/icons3/Record.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Record = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M49 40a24 24 0 0 1-34 0M20 56h24M32 48v8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M40 32a8 8 0 0 1-16 0V16a8 8 0 0 1 16 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Recorder.js
+++ b/src/icons3/Recorder.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Recorder = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="16" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="48" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 40h32"/>
+    <circle cx="16" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="48" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M16 40h32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Remove.js
+++ b/src/icons3/Remove.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Remove = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24M8 8h48v48H8z"/>
+    <path fill="none" stroke="currentColor" d="M20 32h24M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/RemoveCircle.js
+++ b/src/icons3/RemoveCircle.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const RemoveCircle = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 32h24"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 32h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/RhombusNumber.js
+++ b/src/icons3/RhombusNumber.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const RhombusNumber = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M24 8v48M40 8v48M56 24H8M56 40H8"/>
+    <path fill="none" stroke="currentColor" d="M24 8v48M40 8v48M56 24H8M56 40H8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Sandclock.js
+++ b/src/icons3/Sandclock.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sandclock = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M46 8v8c0 8.84-6.27 16-14 16s-14-7.16-14-16V8M12 8h40M18 56v-8c0-8.84 6.27-16 14-16s14 7.16 14 16v8M52 56H12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Save.js
+++ b/src/icons3/Save.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Save = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 8v20H16V8M24 56V44h16v12M32 44v12"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M48 8v20H16V8M24 56V44h16v12M32 44v12" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Scissors.js
+++ b/src/icons3/Scissors.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Scissors = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="16" cy="20" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="16" cy="44" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20.8 37.6L56 20M20.8 26.4L56 44"/>
+    <circle cx="16" cy="20" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="16" cy="44" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20.8 37.6L56 20M20.8 26.4L56 44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Search.js
+++ b/src/icons3/Search.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Search2.js
+++ b/src/icons3/Search2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="24" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L35.31 35.31"/>
+    <circle cx="24" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L35.31 35.31" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Search3.js
+++ b/src/icons3/Search3.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="28" cy="28" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M44 44L33.66 33.66"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="28" cy="28" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M44 44L33.66 33.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Search4.js
+++ b/src/icons3/Search4.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Search4 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 56V40"/><circle cx="32" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 56V40" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Settings.js
+++ b/src/icons3/Settings.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Settings = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32a24.17 24.17 0 0 0-.32-3.89L48 25.37 51.5 18a24.14 24.14 0 0 0-5.5-5.5L38.63 16l-2.74-7.68a24.15 24.15 0 0 0-7.78 0L25.37 16 18 12.5a24.14 24.14 0 0 0-5.5 5.5l3.5 7.37-7.68 2.74a24.15 24.15 0 0 0 0 7.78L16 38.63 12.5 46a24.13 24.13 0 0 0 5.5 5.5l7.37-3.5 2.73 7.69a24.14 24.14 0 0 0 7.78 0L38.63 48 46 51.5a24.13 24.13 0 0 0 5.5-5.5L48 38.63l7.69-2.73A24.18 24.18 0 0 0 56 32z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Shirt.js
+++ b/src/icons3/Shirt.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Shirt = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M44 12.09c3.92 1.62 12 12 12 12l-8 8-4-4v24H20v-24l-4 4-8-8s8.08-10.38 12-12c.92-.38 4 0 4 0 0 4 4 8 8 8s8-4 8-8c0 0 3.08-.39 4 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Sign.js
+++ b/src/icons3/Sign.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sign = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 24v32H8V8h32M24 40L56 8"/>
+    <path fill="none" stroke="currentColor" d="M56 24v32H8V8h32M24 40L56 8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Sign2.js
+++ b/src/icons3/Sign2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sign2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36"/>
+    <path fill="none" stroke="currentColor" d="M20 56l36-36L44 8 8 44v12h12zM12 40l12 12M36 16l12 12M20 56h36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Sliders.js
+++ b/src/icons3/Sliders.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sliders = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16"/>
+    <path fill="none" stroke="currentColor" d="M16 8v48M48 8v48M32 8v48M8 48h16M24 20h16M40 40h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/SmallSteeringWheel2.js
+++ b/src/icons3/SmallSteeringWheel2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const SmallSteeringWheel2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/>
+    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Spinner1.js
+++ b/src/icons3/Spinner1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Spinner1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Spinner2.js
+++ b/src/icons3/Spinner2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Spinner2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48"/>
+    <path fill="none" stroke="currentColor" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Star.js
+++ b/src/icons3/Star.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Star = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z"/>
+    <path fill="none" stroke="currentColor" d="M32 12l6.41 12.84L52 27.28l-9.63 10.38L44.36 52 32 45.58 19.64 52l1.99-14.34L12 27.28l13.59-2.44L32 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/SteeringWheel.js
+++ b/src/icons3/SteeringWheel.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const SteeringWheel = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48"/>
+    <circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v12M32 56V44M56 32H44M8 32h12M48.97 15.03l-8.48 8.48M15.03 48.97l8.48-8.48M48.97 48.97l-8.48-8.48M15.03 15.03l8.48 8.48" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Sun.js
+++ b/src/icons3/Sun.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Sun = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M32 8v8M32 56v-8M56 32h-8M8 32h8M48.97 15.03l-5.66 5.66M15.03 48.97l5.66-5.66M48.97 48.97l-5.66-5.66M15.03 15.03l5.66 5.66" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Switch.js
+++ b/src/icons3/Switch.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Switch = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M48 12l8 8-8 8M48 36l8 8-8 8"/><path d="M56 20H40c-12 0-12 24-24 24H8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M8 20h8c12 0 12 24 24 24h16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M48 12l8 8-8 8M48 36l8 8-8 8" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 20H40c-12 0-12 24-24 24H8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M8 20h8c12 0 12 24 24 24h16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Tag.js
+++ b/src/icons3/Tag.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Tag = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M36 8L8 36l20 20 28-28V8H36z"/><circle cx="44" cy="20" r="4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path fill="none" stroke="currentColor" d="M36 8L8 36l20 20 28-28V8H36z" strokeWidth="4" strokeMiterlimit="10"/><circle cx="44" cy="20" r="4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Target.js
+++ b/src/icons3/Target.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Target = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/TargetCross.js
+++ b/src/icons3/TargetCross.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const TargetCross = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v8M32 48v8M56 32h-8M8 32h8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v8M32 48v8M56 32h-8M8 32h8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/TargetCrossSmall.js
+++ b/src/icons3/TargetCrossSmall.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const TargetCrossSmall = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 8v16M32 40v16M56 32H40M8 32h16"/>
+    <circle cx="32" cy="32" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 8v16M32 40v16M56 32H40M8 32h16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Textfile.js
+++ b/src/icons3/Textfile.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Textfile = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M12 8h40v48H12zM20 32h24M20 20h24M20 44h24"/>
+    <path fill="none" stroke="currentColor" d="M12 8h40v48H12zM20 32h24M20 20h24M20 44h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Time.js
+++ b/src/icons3/Time.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Time = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 44l-8-12V16"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 44l-8-12V16" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Tire.js
+++ b/src/icons3/Tire.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Tire = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M40 24h16M40 40h16M40 40v16M24 40v16M24 40H8M24 24H8M24 24V8M40 24V8" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Token1.js
+++ b/src/icons3/Token1.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token1 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 14v4.5M32 50v-4.5M50 32h-4.5M14 32h4.5M44.73 19.27l-3.18 3.18M19.27 44.73l3.18-3.18M44.73 44.73l-3.18-3.18M19.27 19.27l3.18 3.18" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Token2.js
+++ b/src/icons3/Token2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Token3.js
+++ b/src/icons3/Token3.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Token3 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><circle cx="32" cy="32" r="12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Toolbox.js
+++ b/src/icons3/Toolbox.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Toolbox = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20"/>
+    <path fill="none" stroke="currentColor" d="M8 20h48v32H8zM8 32h48M32 28v8M20 20l2.89-5.78a4 4 0 0 1 3.6-2.22h11a4 4 0 0 1 3.6 2.22L44 20" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Trash.js
+++ b/src/icons3/Trash.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Trash = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44"/>
+    <path fill="none" stroke="currentColor" d="M52 16l-4 40H16l-4-40M20 16v-3.94A4.06 4.06 0 0 1 24.06 8h15.88A4.06 4.06 0 0 1 44 12.06V16M8 16h48M24 28l16 16M40 28L24 44" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Trezor.js
+++ b/src/icons3/Trezor.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Trezor = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M20 27v-7a12 12 0 0 1 24 0v7" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M24.71 25.82L16 28v20l16 8 16-8V28l-8.71-2.18a30.07 30.07 0 0 0-14.58 0z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M20 27v-7a12 12 0 0 1 24 0v7" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Umbrella.js
+++ b/src/icons3/Umbrella.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Umbrella = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32H8c0-11 10.75-20 24-20s24 9 24 20zM32 52a4 4 0 0 1-8 0M32 32v20M32 8v4" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/User.js
+++ b/src/icons3/User.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const User = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/><path d="M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8" fill="none" stroke="currentColor" stroke-miterlimit="3" stroke-width="4"/>
+    <path d="M44 24c0 8.84-4 16-12 16s-12-7.16-12-16c0-12 4-16 12-16s12 4 12 16z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/><path d="M22 33.46s-10.08 2.69-12 8A32.91 32.91 0 0 0 8 56h48a32.91 32.91 0 0 0-1.94-14.54c-1.93-5.31-12-8-12-8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="3"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ViewHidden.js
+++ b/src/icons3/ViewHidden.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ViewHidden = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16zM52 12L12 52M52 52L12 12" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ViewVisible.js
+++ b/src/icons3/ViewVisible.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ViewVisible = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <circle cx="32" cy="32" r="8" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path d="M56 32s-8 16-24 16S8 32 8 32s8-16 24-16 24 16 24 16z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Walletadress.js
+++ b/src/icons3/Walletadress.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Walletadress = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 8h48v48H8z"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 20h24v24H20z"/>
+    <path fill="none" stroke="currentColor" d="M8 8h48v48H8z" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 20h24v24H20z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Warning.js
+++ b/src/icons3/Warning.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Warning = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 16v20M32 44v4"/>
+    <circle cx="32" cy="32" r="24" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 16v20M32 44v4" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Waysign.js
+++ b/src/icons3/Waysign.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Waysign = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 32v24M44 32H8V8h36l12 12-12 12z"/>
+    <path fill="none" stroke="currentColor" d="M28 32v24M44 32H8V8h36l12 12-12 12z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Waysign2.js
+++ b/src/icons3/Waysign2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Waysign2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32"/>
+    <path fill="none" stroke="currentColor" d="M32 40H16l-8-8 8-8h16M32 56V8h16l8 8-8 8H32" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/WindowsLayers.js
+++ b/src/icons3/WindowsLayers.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const WindowsLayers = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 44H8V8h28v20"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M20 28h36v28H20z"/>
+    <path fill="none" stroke="currentColor" d="M20 44H8V8h28v20" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M20 28h36v28H20z" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Women.js
+++ b/src/icons3/Women.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Women = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M8 56l20.69-20.69"/><circle cx="40" cy="24" r="16" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M28 52L12 36"/>
+    <path fill="none" stroke="currentColor" d="M8 56l20.69-20.69" strokeWidth="4" strokeMiterlimit="10"/><circle cx="40" cy="24" r="16" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M28 52L12 36" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Women2.js
+++ b/src/icons3/Women2.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Women2 = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="32" cy="22" r="14" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M32 36v24M40 48H24"/>
+    <circle cx="32" cy="22" r="14" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M32 36v24M40 48H24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/Wrench.js
+++ b/src/icons3/Wrench.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const Wrench = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <path d="M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/>
+    <path d="M55.52 18.37l-3.36 3.36a7 7 0 1 1-9.9-9.9l3.36-3.36A14 14 0 0 0 28.81 26.7L10.34 42.34a8 8 0 0 0 11.32 11.32L37.3 35.19a14 14 0 0 0 18.22-16.82z" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ZoomIn.js
+++ b/src/icons3/ZoomIn.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ZoomIn = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14M16 28h24M28 16v24"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14M16 28h24M28 16v24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 

--- a/src/icons3/ZoomOut.js
+++ b/src/icons3/ZoomOut.js
@@ -3,7 +3,7 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const ZoomOut = props => (
   <SvgIcon {...props} viewBox="0 0 64 64">
-    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4"/><path fill="none" stroke="currentColor" stroke-miterlimit="10" stroke-width="4" d="M56 56L42.14 42.14M16 28h24"/>
+    <circle cx="28" cy="28" r="20" fill="none" stroke="currentColor" strokeWidth="4" strokeMiterlimit="10"/><path fill="none" stroke="currentColor" d="M56 56L42.14 42.14M16 28h24" strokeWidth="4" strokeMiterlimit="10"/>
   </SvgIcon>
 );
 


### PR DESCRIPTION
solution: stroke-width and stroke-miterlevel replaced with camel-case

this is a bit hard to review in the current format so heres a screenshot of the actual changes... just buried in the files changed tab:

![image](https://user-images.githubusercontent.com/364566/38904988-7d1e33ca-4262-11e8-9e61-043d755e7b47.png)
