### PR TITLE
Problem: gas limit field shows tx fee in {token} when it should be ETC

### DIFF
--- a/src/components/CreateTransaction/GasLimitField/index.js
+++ b/src/components/CreateTransaction/GasLimitField/index.js
@@ -47,7 +47,7 @@ class GasLimitField extends React.Component {
           min="21000"
           onChange={this.onChangeGasLimit}
         />
-        <div style={getStyles(this.props.muiTheme)}>{this.props.txFee} {this.props.token}   /   {this.props.txFeeFiat} {this.props.currency}</div>
+        <div style={getStyles(this.props.muiTheme)}>{this.props.txFee} ETC   /   {this.props.txFeeFiat} {this.props.currency}</div>
       </Fragment>
     );
   }


### PR DESCRIPTION
Solution: hard code ETC as tx fee currency


here's a pic of the bug:

![image](https://user-images.githubusercontent.com/364566/41824658-f46cd27e-77c8-11e8-861c-86407f69c122.png)
